### PR TITLE
add kwarg to specify list of countries or part of countries to always skip

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,26 +1,26 @@
-# name: Documentation
+name: Documentation
 
-# on:
-#   push:
-#     branches:
-#       - master # update to match your development branch (master, main, dev, trunk, ...)
-#     tags: '*'
-#   pull_request:
+on:
+  push:
+    branches:
+      - master # update to match your development branch (master, main, dev, trunk, ...)
+    tags: '*'
+  pull_request:
 
-# jobs:
-#   build:
-#     permissions:
-#       contents: write
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v2
-#       - uses: julia-actions/setup-julia@v1
-#         with:
-#           version: '1.9'
-#       - name: Install dependencies
-#         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-#       - name: Build and deploy
-#         env:
-#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
-#           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # If authenticating with SSH deploy key
-#         run: julia --project=docs/ docs/make.jl
+jobs:
+  build:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1.9'
+      - name: Install dependencies
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # If authenticating with SSH deploy key
+        run: julia --project=docs/ docs/make.jl

--- a/src/CountriesBorders.jl
+++ b/src/CountriesBorders.jl
@@ -5,10 +5,11 @@ using Meshes
 using GeoInterface
 using Tables
 
-export extract_countries
+export extract_countries, SKIP_NONCONTINENTAL_EU, SkipFromAdmin
 
 const GEOTABLE = Ref{GeoTables.GeoTable}()
 
+include("skip_polyarea.jl")
 include("implementation.jl")
 
 function __init__()

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -28,10 +28,33 @@ function _process_input(s::String)
 end
 _process_input(v::Array) = vcat(map(_process_input, v)...)
 
+# This function removes from the domain the areas specified in the SkipDict
+function process_domain!(dmn, sd::SkipDict, geotable)
+	removed_idx = falses(length(dmn))
+	isempty(removed_idx) && return dmn
+	for (admin, s) in sd
+		idx = findfirst(startswith(admin), geotable.ADMIN)
+		isnothing(idx) && continue
+		geom = dmn[idx]
+		if skipall(s) || length(geom.items) == length(s.idxs)
+			removed_idx[idx] = true
+		else
+			name = admin
+			lg = length(geom.items)
+			mi = maximum(s.idxs)
+			@assert mi <= lg "The provided idxs to remove from '$name' have at laset one idx ($mi) which is greater than the number of PolyAreas associated to '$name' ($lg PolyAreas)"
+			deleteat!(geom.items, s.idxs)
+		end
+	end
+	all(removed_idx) && @warn "Some countries were downselected but have been removed based on the contents of the `skip_area` keyword argument."
+	deleteat!(dmn.items, removed_idx)
+	return dmn
+end
+
 ## extract_countries ##
 """
-	extract_countries([shapetable::Shapefile.Table]; kwargs...)
-	extract_countries(name::String; kwargs...)
+	extract_countries([shapetable::Shapefile.Table]; skip_areas = nothing, kwargs...)
+	extract_countries(admin::Union{AbstractString, Vector{<:AbstractString}}; skip_areas = nothing, kwargs...)
 
 Extract and returns the domain (`<:Meshes.Domain`) containing all the countries
 that match a search query provided via the kwargs...
@@ -53,7 +76,9 @@ informations among the columns
 The downselection of countries to form a domain is performed by passing keyword
 arguments containing `String` or `Vector{String}` values. 
 
-# Input Parsing
+# Extended Help
+
+## Input Parsing
 
 For each keyword argument, the function performs a downselection on the `shapetable` column whose name matches the keyword argument name. The downselection is done based on the string provided as value:
 - The string is used to match the full name (case-insensitive) with the value of the specified column for each row of the table. 
@@ -64,7 +89,7 @@ For each keyword argument, the function performs a downselection on the `shapeta
 - Each keyword argument is processed in the order it was provided, also modifying the downselection as described in the previous points.
 - The name of the keyword argument is made all uppercase before matching with the column names of `shapefile`, as the column names for the default table are all uppercase, so calling `extract_countries(;ConTinEnt = "Asia")` will match against the `:CONTINENT` column of the `shapefile`.
 
-## Parsing Examples
+### Parsing Examples
 
 - `extract_countries(;continent = "europe", admin="-russia")` will extract the borders of all countries within the european continent except Russia
 - `extract_countries(;admin="-russia", continent = "europe")` will extract the borders of all countries within the european continent **including** Russia. This is because the strings are processed in order, so Russia is first removed and then Europe (which includes Russia) is added.
@@ -76,8 +101,33 @@ For a list of possible column names, call the function
 For a list of the possible values contained in the table for some of the most
 useful colulmn names, call the function
 `CountriesBorders.possible_selector_values()`.
+
+## Skipping Areas
+
+Apart from removing areas with the string parsing synthax detailed above, one can also provide a list of countries (basd on the `ADMIN` name) or subareas of countries by using the `skip_area` keyword argument.
+
+The provided `skip_area` must be an array of elements that can be:
+- instances of `SkipDict`
+- instances of `SkipFromAdmin`
+- instances of objects that can be used directly to construct `SkipFromAdmin` objects:
+  - A single `String`. (will translate to a `SkipFromAdmin` with the provided `String` as `admin` and the Colon (:) as second argument)
+  - instances `t` of `Tuple{<:AbstractString, <:Any}`, in which case the resulting `SkipFromAdmin` will be created as `SkipFromAdmin(t...)`
+
+The provided elements will be merged into a single list of countries/areas to skip which will be removed from the nominal output of `extract_countries`.
+
+A default set of Non-continental EU areas to skip is available in the exported constant `SKIP_NONCONTINENTAL_EU` which can be passed as the `skip_areas` argument (or as one of the elements of the array passed to `skip_areas`).
+
+### Example
+```julia 
+# The following code will extract the borders of Italy, France and Norway without French Guyana (part of France), without Sicily, and without the Svalbard Islands (part of Norway)
+dmn = extract_countries("italy; spain; france; norway"; skip_areas = [
+	("Italy", 2) # This removes the second polygon in the Italy MultiPolyArea, which corresponds to Sicily
+	"Spain" # This will remove Spain in its entirety
+	SKIP_NONCONTINENTAL_EU # This will remove Svalbard and French Guyana
+])
+```
 """
-function extract_countries(shapetable::GeoTables.SHP.Table;kwargs...)
+function extract_countries(shapetable::GeoTables.SHP.Table; skip_areas = nothing, kwargs...)
 	downselection = falses(Tables.rowcount(shapetable))
 	for (k, v) in kwargs
 		key = Symbol(uppercase(string(k)))
@@ -94,17 +144,23 @@ function extract_countries(shapetable::GeoTables.SHP.Table;kwargs...)
 		end
 	end
 	if any(downselection)
-		subset = Tables.subset(shapetable, downselection)
-		return domain(GeoTables.GeoTable(subset))
+		subset = Tables.subset(shapetable, downselection; viewhint = false)
+        geotable = GeoTables.GeoTable(subset)
+        # We extract the domain directly to modify it in case skip_areas are provided
+        dmn = domain(geotable)
+		if skip_areas !== nothing
+			sd = mergeSkipDict(skip_areas)
+			process_domain!(dmn, sd, geotable)
+		end
+		return dmn
 	else
 		return nothing
 	end
 end
-
+# Other convenience methods
 extract_countries(geotable::GeoTables.GeoTable = GEOTABLE[];kwargs...) = extract_countries(getfield(geotable, :table); kwargs...)
-
 # Method that just searches the admin column
-extract_countries(name::AbstractString;kwargs...) = extract_countries(;admin = name, kwargs...)
+extract_countries(name::Union{AbstractString, Vector{<:AbstractString}};kwargs...) = extract_countries(;admin = name, kwargs...)
 
 # Extracting lat/lon coordaintes of the borders
 function extract_plot_coords(pa::PolyArea)

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -19,7 +19,6 @@ function _to_regexp(s::AbstractString)
     pattern = "^$pattern\$"
     return minus_flag, Regex(pattern, 0x040a000a, 0x40000000)
 end
-_to_regexp(r::Regex) = error("This function does not support Regex as input anymore")
 # Transforms string or regexps in a vector of regexps
 function _process_input(s::String)
     # Try to see if there are multiple inputs (separated by ;)

--- a/src/implementation.jl
+++ b/src/implementation.jl
@@ -134,7 +134,7 @@ function extract_countries(shapetable::GeoTables.SHP.Table; skip_areas = nothing
 		r_vec = try
 			_process_input(v)
 		catch
-			error("The kwarg values have to be provided as String or Regex or Arrays of the two")
+			error("The kwarg values have to be provided as String or Vector{String}")
 		end
 		for (remove_from_list, regex) in r_vec
 			col_vals = map(getproperty(shapetable, key)) do str

--- a/src/skip_polyarea.jl
+++ b/src/skip_polyarea.jl
@@ -1,0 +1,108 @@
+"""
+    SkipFromAdmin(admin::AbstractString, idxs::AbstractVector{<:Integer})
+    SkipFromAdmin(admin::AbstractString, idx::Int)
+    SkipFromAdmin(admin::AbstractString, [::Colon])
+Structure used to specify parts of countries to skip when generating contours with [`extract_countries`](@ref).
+
+When instantiated with just a country name or with a name and an instance of the `Colon` (`:`), it will signal that the full country whose ADMIN name starts with `admin` (case sensitive) will be removed from the output of `extract_countries`.
+
+If created with an `admin` name and a list of integer indices, the polygons at the provided indices will be removed from the `MultiPolyArea` associated to country `admin` if this is present in the ou tput of `extract_countries`.
+
+## Note
+The constructor does not perform any validation to verify that the provided `admin` exists or that the provided `idxs` are valid for indexing into the `MultiPolyArea` associated to the borders of `admin`.
+"""
+struct SkipFromAdmin
+    admin::String
+    idxs::Vector{Int}
+    function SkipFromAdmin(admin::AbstractString, idxs::Vector{Int}) 
+        @assert !isempty(idxs) "You can't initialize a SkipFromAdmin with an empty idxs vector as that represents skipping all PolyAreas. Call `SkipFromAdmin(admin, :)` if you want to explicitly skip all PolyAreas"
+        @assert minimum(idxs) > 0 "One of the provided idxs is lower than 1, this is not allowed."
+        sort!(idxs)
+        unique!(idxs)
+        new(String(admin), idxs)
+    end
+    SkipFromAdmin(admin::AbstractString, ::Colon) = new(String(admin), Int[])
+end
+SkipFromAdmin(admin, idxs::AbstractVector{<:Integer}) = SkipFromAdmin(admin, Int.(collect(idxs)))
+SkipFromAdmin(admin, idx::Int) = SkipFromAdmin(admin, [idx])
+SkipFromAdmin(admin::AbstractString) = SkipFromAdmin(admin, :)
+SkipFromAdmin(t::Tuple{<:AbstractString, <:Any}) = SkipFromAdmin(t...)
+
+skipall(s::SkipFromAdmin) = isempty(s.idxs)
+
+function Base.merge!(a::SkipFromAdmin, bs::SkipFromAdmin...)
+    @assert all(b -> b.admin == a.admin, bs) "You are trying to merge two `SkipFromAdmin` instances with different admin names"
+    # If the first already skips all, we just return it
+    skipall(a) && return a
+    if any(skipall, bs)
+        # We empty the idxs of a
+        empty!(a.idxs)
+    else
+        for b in bs
+            append!(a.idxs, b.idxs)
+        end
+        sort!(a.idxs)
+        unique!(a.idxs)
+    end
+    return a
+end
+Base.merge(a::SkipFromAdmin, bs::SkipFromAdmin...) = merge!(deepcopy(a), bs...)
+
+const SkipDict = Dict{String, SkipFromAdmin}
+
+"""
+    validate_skipDict(d::SkipDict; geotable = GEOTABLE[])
+Verify that the provided `SkipDict` contains only valid entries w.r.t. `geotable`.
+
+An entry is valid if the `admin` name exists in `geotable` and if the corresponding `idxs` to be skipped are valid indices to the PolyAreas associated to the country identified by `admin`
+"""
+function validate_skipDict(d::SkipDict; geotable = GEOTABLE[])
+    ADMIN = geotable.ADMIN
+    foreach(d) do (name, s)
+        idxs = findall(startswith(name), ADMIN)
+        l = length(idxs)
+        @assert l > 0 error("The admin name '$name' has no match in the geotable, use the exact name of the country to generate `SkipFromAdmin` (Case sensitive)")
+        @assert l < 2 error("The admin name '$name' matches more than one row of the geotable, use the exact name of the country to generate `SkipFromAdmin`")
+        # If we skip all polyareas we just return without doing the last check
+        skipall(s) && return
+        idx = first(idxs)
+        geom = geotable.geometry[idx]
+        lg = length(geom.items)
+        mi = maximum(s.idxs)
+        @assert mi <= lg "The provided idxs to remove from '$name' have at laset one idx ($mi) which is greater than the number of PolyAreas associated to '$name' ($lg PolyAreas)"
+    end
+end
+
+# We pass through a Dict to enforce uniqueness of the skipped admin names
+skipDict(s::SkipFromAdmin) = SkipDict(s.admin => s)
+skipDict(d::SkipDict) = d
+skipDict(v::Vector{SkipFromAdmin}) = mergeSkipDict(v)
+skipDict(x) = SkipFromAdmin(x) |> skipDict
+
+# Taken basically from Base.merge(d::AbstractDict, others::AbstractDict...)
+function Base.merge!(d::SkipDict, others::SkipDict...)
+        for other in others
+        if Base.haslength(d) && Base.haslength(other)
+            sizehint!(d, length(d) + length(other))
+        end
+        for (k,v) in other
+            if haskey(d, k)
+                merge!(d[k], v)
+            else
+                d[k] = deepcopy(v)
+            end
+        end
+    end
+    return d
+end
+
+mergeSkipDict(args...) = merge(map(skipDict, args)...)
+mergeSkipDict(v::AbstractVector) = mergeSkipDict(v...)
+
+# We create a function to skip non continental EU polyareas
+const SKIP_NONCONTINENTAL_EU = [
+	SkipFromAdmin("France", 1) # This skips Guyana
+	SkipFromAdmin("Norway", [
+		1, 3, 4 # Continental Norway is the 2nd PolyArea only
+	])
+] |> skipDict

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Meshes = "eacbb407-ea5a-433e-ab97-5258b1ca43fa"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Meshes = "eacbb407-ea5a-433e-ab97-5258b1ca43fa"
+PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -53,6 +53,9 @@ dm2 = extract_countries(["italy","spain","france","norway"])
 possible_selector_values()
 valid_column_names()
 
+# Test that extract_countries returns nothing if no matching country is found
+@test extract_countries("IDFSDF") === nothing
+
 # skip_polyarea coverage
 sfa1 = SkipFromAdmin("France", :)
 sfa2 = SkipFromAdmin("France", 1)
@@ -68,6 +71,7 @@ sd = mergeSkipDict([
 validate_skipDict(sd) # Check it doesn't error
 @test_throws "more than one row" validate_skipDict(skipDict(("A", :)))
 @test_throws "no match" validate_skipDict(skipDict(("Axiuoiasdf", :)))
+@test_throws "greater than" validate_skipDict(skipDict(("Italy", 35)))
 
 sfa3 = merge(sfa2, sfa1)
 @test skipall(sfa3)
@@ -75,3 +79,9 @@ sfa3 = merge(sfa2, sfa1)
 sfa4 = merge!(sfa2, sfa1)
 @test skipall(sfa4)
 @test skipall(sfa2) # merge! should have changed sfa2
+
+sfa = SkipFromAdmin("France", 1)
+sfb = SkipFromAdmin("France", 1:3)
+@test sfb.idxs != sfa.idxs
+merge!(sfa, SkipFromAdmin("France", 2), SkipFromAdmin("France", 3))
+@test sfb.idxs == sfa.idxs

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,0 +1,41 @@
+using CountriesBorders
+using Meshes
+
+example1 = extract_countries(;continent = "europe", admin="-russia")
+example2 = extract_countries(;admin="-russia", continent = "europe")
+example3 = extract_countries(;subregion = "*europe; -eastern europe")
+@testset "Test Docstring Examples" begin
+    @test !isnothing(example1)
+    @test !isnothing(example2)
+    @test !isnothing(example3)
+    @test length(example2) == length(example1) + 1
+    @test !isnothing(extract_countries(;ConTinEnt = "Asia"))
+
+    # We test the skip_areas example
+
+    included_cities = cities = [
+        (12.49, 41.9) # Rome
+        (9.113, 39.217) # Cagliari
+        (2.349, 48.864) # Paris
+        (10.738, 59.913) # Oslo
+    ] .|> Meshes.Point
+
+    excluded_cities = cities = [
+        (15.09, 37.5) # Catania
+        (-3.703, 40.416) # Madrid
+        (-52.773, 5.212) # Guiana Space Center
+        (15.652, 78.222) # Svalbard Museum
+    ] .|> Meshes.Point
+
+    dmn_excluded = extract_countries("italy; spain; france; norway"; skip_areas = [
+        ("Italy", 2)
+        "Spain"
+        SKIP_NONCONTINENTAL_EU
+    ])
+    @test all(in(dmn_excluded), included_cities)
+    @test all(!in(dmn_excluded), excluded_cities)
+
+    dmn_full = extract_countries("italy; spain; france; norway")
+    @test all(in(dmn_full), included_cities)
+    @test all(in(dmn_full), excluded_cities)
+end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -39,3 +39,11 @@ example3 = extract_countries(;subregion = "*europe; -eastern europe")
     @test all(in(dmn_full), included_cities)
     @test all(in(dmn_full), excluded_cities)
 end
+
+# We test the array method
+dm1 = extract_countries("italy; spain; france; norway")
+dm2 = extract_countries(["italy","spain","france","norway"])
+@test length(dm1) == length(dm2)
+
+# We test that sending a regex throws
+@test_throws "Vector{String}" extract_countries(; admin = r"france")

--- a/test/extensions.jl
+++ b/test/extensions.jl
@@ -1,0 +1,7 @@
+using CountriesBorders
+using PlotlyBase
+
+# We just call scattergeo to try that it doesn't error
+dmn = extract_countries("Italy")
+
+dmn |> scattergeo

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,3 +5,4 @@ Aqua.test_all(CountriesBorders; ambiguities = false)
 Aqua.test_ambiguities(CountriesBorders)
 
 @safetestset "Basic" begin include("basics.jl") end
+@safetestset "Extensions" begin include("extensions.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,18 +4,4 @@ using CountriesBorders
 Aqua.test_all(CountriesBorders; ambiguities = false)
 Aqua.test_ambiguities(CountriesBorders)
 
-
-@safetestset "Basic" begin
-    using CountriesBorders
-
-    example1 = extract_countries(;continent = "europe", admin="-russia")
-    example2 = extract_countries(;admin="-russia", continent = "europe")
-    example3 = extract_countries(;subregion = "*europe; -eastern europe")
-    @testset "Test Docstring Examples" begin
-        @test !isnothing(example1)
-        @test !isnothing(example2)
-        @test !isnothing(example3)
-        @test length(example2) == length(example1) + 1
-        @test !isnothing(extract_countries(;ConTinEnt = "Asia"))
-    end
-end
+@safetestset "Basic" begin include("basics.jl") end


### PR DESCRIPTION
This PR add a new keyword argument `skip_areas` to the `extract_countries` function to provide a list of countries or parts of countries (distinct polygons composing a MultiPolyArea identifying the borders of the country) to be always removed by the domain extracted with `extract_countries` before returning it.

![image](https://github.com/disberd/CountriesBorders.jl/assets/12846528/5f4088bb-2cd1-4bd7-8e7e-347c95c445cd)

This should fix #1 