### PR TITLE
add longitude wrap and latitude assert

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -34,11 +34,19 @@ using CoordRefSystems: Deg, Rad, Geographic, Datum, addunit, WGS84Latest
     SimpleLatLon{Datum}(lat, lon)
 Simple structure mirroring `LatLon` from CoordRefSystems. It defaults to Float32 precision on the fields (expressed in ° from Unitful) and is used to simplify the check for inclusion in a 2d PolyArea on the world.
 
+Contrary to `LatLon`, the constructor for LatLon also enforces the latitude to be between -90° and 90°, and wraps the longitude so it's value is ensured to be between -180° and 180°.
+
 The domain returned from [`extract_countries`](@ref) is composed of `Meshes.Point` points with `SimpleLatLon` coordinates.
 """
 struct SimpleLatLon{Datum,D<:Deg} <: Geographic{Datum}
     lat::D
     lon::D
+    function SimpleLatLon{Datum, D}(lat::Deg, lon::Deg) where {Datum, D}
+        @assert abs(lat) <= π/2 "You must provide a latitude between -90° and 90°"
+        # We wrap directly the lon to make sure it's 
+        lon = rem(lon, 360u"°", RoundNearest)
+        new{Datum, D}(lat, lon)
+    end
 end
 
 const Deg32 = typeof(1f0u"°")

--- a/src/types.jl
+++ b/src/types.jl
@@ -100,4 +100,15 @@ end
 const SimpleRegion{Datum, D} = Union{PolyArea{2, SimpleLatLon{Datum, D}}, Multi{2, SimpleLatLon{Datum, D}}, Domain{2, SimpleLatLon{Datum, D}}}
 
 # Add specific catchall methods for `in`
-Base.in(p::Union{SimpleLatLon, LatLon}, region::SimpleRegion{Datum, D}) where {Datum, D} = Base.in(SimpleLatLon{Datum, D}(p) |> Point, region)
+function Base.in(ll::Union{SimpleLatLon, LatLon}, region::SimpleRegion{Datum, D}) where {Datum, D} 
+    sll = SimpleLatLon{Datum, D}(ll)
+    return Point(sll) in region
+end
+
+# Add a method for `in` for NamedTuple inputs
+function Base.in(nt::Union{NamedTuple{(:lat, :lon)}, NamedTuple{(:lon, :lat)}}, region::SimpleRegion{Datum, D}) where {Datum, D}
+    (;lat, lon) = nt
+    sll = SimpleLatLon{Datum}(lat, lon)
+    sll_D = convert(SimpleLatLon{Datum, D}, sll)
+    return Point(sll_D) in region
+end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -119,3 +119,15 @@ merge!(sfa, SkipFromAdmin("France", 2), SkipFromAdmin("France", 3))
 end
 
 @test_throws "geometry column not found" geomcolumn([:asd, :lol])
+
+@testset "in" begin
+    dmn = extract_countries("italy")
+
+    rome_sll = SimpleLatLon(41.9, 12.49)
+    rome_ll = LatLon(41.9, 12.49)
+    rome_nt1 = (;lat = 41.9, lon = 12.49)
+    rome_nt2 = (;lon = 12.49, lat = 41.9)
+    for p in (rome_sll, rome_ll, rome_nt1, rome_nt2)
+        @test p in dmn
+    end
+end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -39,6 +39,9 @@ example3 = extract_countries(;subregion = "*europe; -eastern europe")
     @test all(in(dmn_excluded), included_cities)
     @test all(!in(dmn_excluded), excluded_cities)
 
+    # Check wrapping
+    @test SimpleLatLon(41.9, 12.49 + 360) in dmn_excluded
+
     dmn_full = extract_countries("italy; spain; france; norway")
     @test all(in(dmn_full), included_cities)
     @test all(in(dmn_full), excluded_cities)
@@ -99,6 +102,7 @@ merge!(sfa, SkipFromAdmin("France", 2), SkipFromAdmin("France", 3))
         end
         return true
     end
+    ≈(a,b) = Base.isapprox(a,b)
     sll_wgs = SimpleLatLon(10,20)
     ll_wgs = convert(LatLon{WGS84Latest}, sll_wgs)
     ll_itrf = convert(LatLon{ITRF{2008}}, sll_wgs)
@@ -108,6 +112,10 @@ merge!(sfa, SkipFromAdmin("France", 2), SkipFromAdmin("France", 3))
     @test sll_itrf ≈ convert(SimpleLatLon{ITRF{2008}}, sll_wgs)
     rad = 1u"rad"
     @test SimpleLatLon(90,90) ≈ SimpleLatLon(π/2 * rad, π/2 * rad)
+
+    # Test constructor errors and longitude wrapping
+    @test_throws "between -90° and 90°" SimpleLatLon(180, 2)
+    @test SimpleLatLon(0, 41 + 360).lon |> ustrip ≈ 41
 end
 
 @test_throws "geometry column not found" geomcolumn([:asd, :lol])


### PR DESCRIPTION
This MR implements two checks in the SimpleLatLon inner constructor:
- It throws if the latitude is not within -90° and 90°
- It automatically wraps the longitude before storing it so that it falls between -180° and 180°

It also adds an additional method for `Base.in(nt, region::SimpleRegion)` when nt is a NamedTuple containing the lat and lon fields