### PR TITLE
fix swapped args in extract_plot_coords

### DIFF
--- a/src/plot_coordinates.jl
+++ b/src/plot_coordinates.jl
@@ -34,7 +34,13 @@ end
 geom_iterable(pa::Union{Multi, PolyArea}) = rings(pa)
 geom_iterable(d::Domain) = d
 
-function extract_plot_coords(inp::Union{Multi{2, <:SimpleLatLon}, Domain{2, <:SimpleLatLon}, PolyArea{2, <:SimpleLatLon}})
+"""
+    extract_plot_coords(inp)
+Extract the lat and lon coordinates from the geometry/region `inp` and return them in a NamedTuple with fields `lat` and `lon` being vectors of `Float32` elements representing the lat/lon coordinates in degrees.
+
+When `inp` is composed of multiple rings/polygons, the returned vectors `lat` and `lon` contain the concateneated lat/lon values of each ring separated by `NaN32` values. This is done to allow plotting multiple separated borders in a single trace.
+"""
+function extract_plot_coords(inp::SimpleRegion)
     iterable = geom_iterable(inp)
     length(iterable) == 1 && return extract_plot_coords(first(iterable))
 	lon = Float32[]

--- a/src/plot_coordinates.jl
+++ b/src/plot_coordinates.jl
@@ -36,9 +36,13 @@ geom_iterable(d::Domain) = d
 
 """
     extract_plot_coords(inp)
-Extract the lat and lon coordinates from the geometry/region `inp` and return them in a NamedTuple with fields `lat` and `lon` being vectors of `Float32` elements representing the lat/lon coordinates in degrees.
+Extract the lat and lon coordinates (in degrees) from the geometry/region `inp`
+and return them in a `@NamedTuple{lat::Vector{Float32}, lon::Vector{Float32}`.
 
-When `inp` is composed of multiple rings/polygons, the returned vectors `lat` and `lon` contain the concateneated lat/lon values of each ring separated by `NaN32` values. This is done to allow plotting multiple separated borders in a single trace.
+When `inp` is composed of multiple rings/polygons, the returned vectors `lat`
+and `lon` contain the concateneated lat/lon values of each ring separated by
+`NaN32` values. This is done to allow plotting multiple separated borders in a
+single trace.
 """
 function extract_plot_coords(inp::SimpleRegion)
     iterable = geom_iterable(inp)

--- a/src/plot_coordinates.jl
+++ b/src/plot_coordinates.jl
@@ -48,5 +48,5 @@ function extract_plot_coords(inp::Union{Multi{2, <:SimpleLatLon}, Domain{2, <:Si
             push!(lon, NaN32)
         end
 	end
-	(;lon,lat)
+	(;lat, lon)
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -105,11 +105,11 @@ merge!(sfa, SkipFromAdmin("France", 2), SkipFromAdmin("France", 3))
     ≈(a,b) = Base.isapprox(a,b)
     sll_wgs = SimpleLatLon(10,20)
     ll_wgs = convert(LatLon{WGS84Latest}, sll_wgs)
-    ll_itrf = convert(LatLon{ITRF{2008}}, sll_wgs)
-    sll_itrf = convert(SimpleLatLon{ITRF{2008}}, ll_itrf)
-    ll_itrf2 = convert(LatLon{ITRF{2008}}, LatLon(10f0,20f0))
+    ll_itrf = convert(LatLon{ITRF{2020}}, sll_wgs)
+    sll_itrf = convert(SimpleLatLon{ITRF{2020}}, ll_itrf)
+    ll_itrf2 = convert(LatLon{ITRF{2020}}, LatLon(10f0,20f0))
     @test sll_itrf ≈ ll_itrf ≈ ll_itrf2
-    @test sll_itrf ≈ convert(SimpleLatLon{ITRF{2008}}, sll_wgs)
+    @test sll_itrf ≈ convert(SimpleLatLon{ITRF{2020}}, sll_wgs)
     rad = 1u"rad"
     @test SimpleLatLon(90,90) ≈ SimpleLatLon(π/2 * rad, π/2 * rad)
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,5 +1,5 @@
 using CountriesBorders
-using CountriesBorders: possible_selector_values, valid_column_names, mergeSkipDict, validate_skipDict, skipall, SkipDict, skipDict, GeoTablesConversion.geomcolumn, get_geotable
+using CountriesBorders: possible_selector_values, valid_column_names, mergeSkipDict, validate_skipDict, skipall, SkipDict, skipDict, GeoTablesConversion.geomcolumn, get_geotable, extract_plot_coords
 using Meshes
 using CoordRefSystems
 using Test
@@ -134,3 +134,9 @@ end
 
 # We test that 50m resolution has more polygons than the default 110m one
 @test length(get_geotable(;resolution = 50).geometry) > length(get_geotable().geometry)
+
+# We test that extract_plot_coords gives first lat and then lon
+@testset "Extract plot coords" begin
+    dmn = extract_countries("italy")
+    @test extract_plot_coords(dmn) isa @NamedTuple{lat::Vector{Float32}, lon::Vector{Float32}}
+end


### PR DESCRIPTION
this PR fixes a consistency bug in the output of the un-exported `extract_plot_coords` function where the order of lat and lon in the output would be different in the returned NamedTuple.

This now ensure a consistent output where `lat` is the first vector in the NamedTuple.

As part of this PR, the error in the conversion tests is also fixed now 