### PR TITLE
fix longitude wrapping issues in latlon geometries

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -8,6 +8,7 @@ module GeoTablesConversion
     using CoordRefSystems
     using CoordRefSystems: Deg, Met
     using Unitful
+    using Unitful: °
 
     export CountryBorder, DOMAIN, remove_polyareas!
 

--- a/test/meshes_interface.jl
+++ b/test/meshes_interface.jl
@@ -1,10 +1,12 @@
-using Meshes
-using CountriesBorders
-using CountriesBorders: borders
-using CoordRefSystems
-using Test
+@testsnippet InterfacesSetup begin
+    using Meshes
+    using CountriesBorders
+    using CountriesBorders: borders
+    using CoordRefSystems
+    using Test
+end
 
-@testset "Meshes interface" begin
+@testitem "Meshes interface" setup=[InterfacesSetup] begin
     italy = extract_countries("italy") |> only
     @test measure(italy) == measure(borders(LatLon, italy))
     @test nvertices(italy) == nvertices(borders(LatLon, italy))
@@ -18,4 +20,9 @@ using Test
     @test vertices(italy) == vertices(borders(Cartesian, italy))
     @test simplexify(italy) == simplexify(borders(Cartesian, italy))
     @test pointify(italy) == pointify(borders(Cartesian, italy))
+end
+
+@testitem "Longitude Wrapping" setup=[InterfacesSetup] begin
+    russia = extract_countries("russia")
+    @test all(!in(russia), [LatLon(lat, -100) for lat in -30:.01:75])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,6 @@ end
 
 @testitem "Basic" begin include("basics.jl") end
 @testitem "Extensions" begin include("extensions.jl") end
-@testitem "Meshes Interface" begin include("meshes_interface.jl") end
+# include("meshes_interface.jl")
 
 @run_package_tests verbose=true


### PR DESCRIPTION
This monkey patch PR fixes the issue in https://github.com/JuliaGeometry/Meshes.jl/issues/1027 by modifying affected rings during construction of a CountryBorder instance.

It is a hotfix that relies on CoordRefSystems internals and should be reverted once an upstream fix is merged (probably https://github.com/JuliaEarth/CoordRefSystems.jl/pull/164).