### PR TITLE
make fix_lon_wrap! no op with latest CoordRefSystems

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CountriesBorders"
 uuid = "ee40d4b5-31c3-4fe2-b6cc-5ac7adf7f414"
 authors = ["Alberto Mengali <disberd@gmail.com>"]
-version = "0.4.1"
+version = "0.4.2-DEV"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -25,7 +25,7 @@ PlotlyBaseExt = "PlotlyBase"
 [compat]
 Artifacts = "1"
 CircularArrays = "1.4.0"
-CoordRefSystems = "0.10, 0.11, 0.12"
+CoordRefSystems = "0.10, 0.11, 0.12, 0.13"
 GeoInterface = "1"
 GeoJSON = "0.8"
 GeoTables = "1"

--- a/src/main_type.jl
+++ b/src/main_type.jl
@@ -89,6 +89,9 @@ end
 # longitude ≈ 180° to -180° in case the rest of the points have mostly negative
 # longitude   
 function fix_lon_wrap!(ring::RING_LATLON{T}) where T
+    @static if pkgversion(CoordRefSystems) ≥ v"0.12.1"
+        return nothing # CoordRefSystems.jl v0.12.1 fixed the underlying issue so we do nothing
+    end
     verts = vertices(ring)
     get_lon(ll::LATLON) = ll.lon
     get_lon(p::Point) = coords(p) |> get_lon


### PR DESCRIPTION
This PR reduces coverage since tests are run with a more recent version fo CRS.jl which skips some part of the code and reduces coverage.

The now no-op function will be removed once we consolidate our packages depending on this so that they all migrated to CoordRefSystems > 0.12.1