### PR TITLE
refactor to speed up `in` checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- The `CountryBorder` type now has a new field `bboxes` which contains the bounding boxes (Cartesian) of each polyarea within the country. This is used to speed up the inclusion test in the new custom `in` implementation using the `in_exit_early` internal function. This brings speedups of 1-2 orders of magnitude compared to the previous implementation.
+- The `CountryBorder` type now has a new field `bboxes` which contains the bounding boxes (Cartesian) of each polyarea within the country. This is used to speed up the inclusion test in the new custom `in` implementation using the `in_exit_early` internal function. This brings speedups of ~20x compared to the previous implementation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+- The `CountryBorder` type now has a new field `bboxes` which contains the bounding boxes (Cartesian) of each polyarea within the country. This is used to speed up the inclusion test in the new custom `in` implementation using the `in_exit_early` internal function. This brings speedups of 1-2 orders of magnitude compared to the previous implementation.

--- a/notebooks/example_use.jl
+++ b/notebooks/example_use.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.45
+# v0.20.4
 
 using Markdown
 using InteractiveUtils

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -18,4 +18,4 @@ module GeoTablesConversion
 end
 
 using .GeoTablesConversion
-using .GeoTablesConversion: VALID_POINT, LATLON, CART, VALID_RING, GSET
+using .GeoTablesConversion: VALID_POINT, LATLON, CART, VALID_RING, GSET, POLY_CART, BOX_CART, POINT_LATLON, POINT_CART

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -18,4 +18,4 @@ module GeoTablesConversion
 end
 
 using .GeoTablesConversion
-using .GeoTablesConversion: VALID_POINT, LATLON, CART, VALID_RING, GSET, POLY_CART, BOX_CART, POINT_LATLON, POINT_CART
+using .GeoTablesConversion: VALID_POINT, LATLON, CART, VALID_RING, GSET, POLY_CART, BOX_CART, POINT_LATLON, POINT_CART, MULTI_CART

--- a/src/main_type.jl
+++ b/src/main_type.jl
@@ -3,11 +3,11 @@ const CART{T} = Cartesian2D{WGS84Latest,Met{T}}
 
 const POINT_LATLON{T} = Point{🌐, LATLON{T}}
 const POINT_CART{T} = Point{𝔼{2}, CART{T}}
-const VALID_POINT = Union{POINT_LATLON, POINT_CART}
+const VALID_POINT{T} = Union{POINT_LATLON{T}, POINT_CART{T}}
 
 const RING_LATLON{T} = Ring{🌐, LATLON{T}, CircularArray{POINT_LATLON{T}, 1, Vector{POINT_LATLON{T}}}}
 const RING_CART{T} = Ring{𝔼{2}, CART{T}, CircularArray{POINT_CART{T}, 1, Vector{POINT_CART{T}}}}
-const VALID_RING = Union{RING_LATLON, RING_CART}
+const VALID_RING{T} = Union{RING_LATLON{T}, RING_CART{T}}
 
 const POLY_LATLON{T} = PolyArea{🌐, LATLON{T}, RING_LATLON{T}, Vector{RING_LATLON{T}}}
 const POLY_CART{T} = PolyArea{𝔼{2}, CART{T}, RING_CART{T}, Vector{RING_CART{T}}}

--- a/src/meshes_interface.jl
+++ b/src/meshes_interface.jl
@@ -16,7 +16,7 @@ resolution(d::DOMAIN) = resolution(element(d, 1))
 polyareas(x) = polyareas(borders(Cartesian, x))
 polyareas(v::Vector{<:POLY_CART}) = v
 polyareas(x::MULTI_CART) = parent(x)
-polyareas(x::POLY_CART) = [x]
+polyareas(x::POLY_CART) = (x,)
 
 # This should return the cartesian bounding boxes for the polyareas of x, mostly to be used with in_exit_early
 bboxes(x) = map(boundingbox, polyareas(x))
@@ -86,7 +86,8 @@ Both `polys` and `bboxes` must be vectors of the same size, with element type `P
 
 This function is basically pre-filtering points by checking inclusion in the bounding box which is significantly faster than checking for the polyarea itself.
 """
-function in_exit_early(p, polys::Vector{<:POLY_CART{T}}, bboxes::Vector{<:BOX_CART{T}}) where T
+function in_exit_early(p, polys, bboxes)
+    T = eltype(polys) |> crs |> CoordRefSystems.mactype
     p = to_cart_point(p, T)
     for i in eachindex(polys, bboxes)
         p in bboxes[i] || continue
@@ -101,7 +102,7 @@ to_cart_point(p::POINT_CART, T::Type{<:Real} = Float32) = convert(POINT_CART{T},
 to_cart_point(p::POINT_LATLON, T::Type{<:Real} = Float32) = to_cart_point(Meshes.flat(p), T)
 to_cart_point(p::Union{LATLON, CART}, T::Type{<:Real} = Float32) = to_cart_point(Point(p), T)
 
-Base.in(p::VALID_POINT, cb::CountryBorder) = in_exit_early(p, parent(Cartesian, cb), cb.bboxes)
+Base.in(p::VALID_POINT, cb::CountryBorder) = in_exit_early(p, cb)
 Base.in(p::LATLON, dmn::Union{DOMAIN, CountryBorder}) = in(Point(p), dmn)
 
 # IO related

--- a/src/meshes_interface.jl
+++ b/src/meshes_interface.jl
@@ -2,8 +2,13 @@
 const VALID_CRS = Type{<:Union{LatLon, Cartesian}}
 
 # These are methods which are not really part of meshes
-floattype(::CountryBorder{T}) where {T} = T
-floattype(::DOMAIN{T}) where {T} = T
+floattype(::Type{<:CountryBorder{T}}) where {T} = T
+floattype(::Type{<:DOMAIN{T}}) where {T} = T
+floattype(::Type{<:Geometry{🌐,LATLON{T}}}) where T = T
+floattype(::Type{<:Geometry{𝔼{2},CART{T}}}) where T = T
+floattype(::Type{<:Union{LATLON{T}, CART{T}}}) where T = T
+floattype(::Type{<:VALID_POINT{T}}) where T = T
+floattype(x) = floattype(typeof(x))
 
 borders(::Type{LatLon}, cb::CountryBorder) = cb.latlon
 borders(::Type{Cartesian}, cb::CountryBorder) = cb.cart
@@ -89,7 +94,7 @@ Both `polys` and `bboxes` must be vectors of the same size, with element type `P
 This function is basically pre-filtering points by checking inclusion in the bounding box which is significantly faster than checking for the polyarea itself.
 """
 function in_exit_early(p, polys, bboxes)
-    T = first(polys) |> crs |> CoordRefSystems.mactype
+    T = first(polys) |> floattype
     p = to_cart_point(p, T)
     for (poly, box) in zip(polys, bboxes)
         p in box || continue

--- a/src/meshes_interface.jl
+++ b/src/meshes_interface.jl
@@ -87,11 +87,11 @@ Both `polys` and `bboxes` must be vectors of the same size, with element type `P
 This function is basically pre-filtering points by checking inclusion in the bounding box which is significantly faster than checking for the polyarea itself.
 """
 function in_exit_early(p, polys, bboxes)
-    T = eltype(polys) |> crs |> CoordRefSystems.mactype
+    T = first(polys) |> crs |> CoordRefSystems.mactype
     p = to_cart_point(p, T)
-    for i in eachindex(polys, bboxes)
-        p in bboxes[i] || continue
-        p in polys[i] && return true
+    for (poly, box) in zip(polys, bboxes)
+        p in box || continue
+        p in poly && return true
     end
     return false
 end

--- a/src/meshes_interface.jl
+++ b/src/meshes_interface.jl
@@ -81,6 +81,10 @@ Both `polys` and `bboxes` must be vectors of the same size, with element type `P
 
 This function is basically pre-filtering points by checking inclusion in the bounding box which is significantly faster than checking for the polyarea itself.
 """
+function in_exit_early(p, poly::POLY_CART{T}, bbox::BOX_CART{T}) where T 
+    p = to_cart_point(p, T)
+    return p in bbox && p in poly
+end
 function in_exit_early(p, polys::Vector{<:POLY_CART{T}}, bboxes::Vector{<:BOX_CART{T}}) where T
     p = to_cart_point(p, T)
     for i in eachindex(polys, bboxes)

--- a/src/meshes_interface.jl
+++ b/src/meshes_interface.jl
@@ -17,10 +17,12 @@ polyareas(x) = polyareas(borders(Cartesian, x))
 polyareas(v::Vector{<:POLY_CART}) = v
 polyareas(x::MULTI_CART) = parent(x)
 polyareas(x::POLY_CART) = (x,)
+polyareas(dmn::DOMAIN) = Iterators.flatten(polyareas(el) for el in dmn)
 
 # This should return the cartesian bounding boxes for the polyareas of x, mostly to be used with in_exit_early
 bboxes(x) = map(boundingbox, polyareas(x))
 bboxes(cb::CountryBorder) = cb.bboxes
+bboxes(dmn::DOMAIN) = Iterators.flatten(bboxes(el) for el in dmn)
 
 # LatLon fallbacks
 Meshes.measure(cb::CountryBorder) = measure(borders(LatLon, cb))

--- a/src/skip_polyarea.jl
+++ b/src/skip_polyarea.jl
@@ -6,7 +6,7 @@ Structure used to specify parts of countries to skip when generating contours wi
 
 When instantiated with just a country name or with a name and an instance of the `Colon` (`:`), it will signal that the full country whose ADMIN name starts with `admin` (case sensitive) will be removed from the output of `extract_countries`.
 
-If created with an `admin` name and a list of integer indices, the polygons at the provided indices will be removed from the `MultiPolyArea` associated to country `admin` if this is present in the ou tput of `extract_countries`.
+If created with an `admin` name and a list of integer indices, the polygons at the provided indices will be removed from the `MultiPolyArea` associated to country `admin` if this is present in the output of `extract_countries`.
 
 ## Note
 The constructor does not perform any validation to verify that the provided `admin` exists or that the provided `idxs` are valid for indexing into the `MultiPolyArea` associated to the borders of `admin`.

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,5 +1,5 @@
 using CountriesBorders
-using CountriesBorders: possible_selector_values, valid_column_names, mergeSkipDict, validate_skipDict, skipall, SkipDict, skipDict, get_geotable, extract_plot_coords, borders, remove_polyareas!, floattype, npolyareas, to_cart_point, change_geometry, Cartesian, in_exit_early
+using CountriesBorders: possible_selector_values, valid_column_names, mergeSkipDict, validate_skipDict, skipall, SkipDict, skipDict, get_geotable, extract_plot_coords, borders, remove_polyareas!, floattype, to_cart_point, change_geometry, Cartesian, in_exit_early, polyareas
 using CountriesBorders.GeoTablesConversion: POINT_CART
 using Meshes
 using CoordRefSystems
@@ -10,7 +10,7 @@ using Unitful
 poly = map([(-1,-1), (-1, 1), (1, 1), (1, -1)]) do p 
     LatLon(p...) |> Point
 end |> PolyArea |> change_geometry(Cartesian)
-@test in_exit_early(centroid(poly), poly, boundingbox(poly))
+@test in_exit_early(LatLon(0,0), poly)
 
 
 example1 = extract_countries(;continent = "europe", admin="-russia")
@@ -133,6 +133,7 @@ end
 
 @testset "Misc coverage" begin
     italy = extract_countries("italy") |> only
+    npolyareas(x) = length(polyareas(x))
     @test LatLon(41.9, 12.49) in italy
     @test npolyareas(italy) == 3
     remove_polyareas!(italy, 1)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,10 +1,12 @@
 using CountriesBorders
-using CountriesBorders: possible_selector_values, valid_column_names, mergeSkipDict, validate_skipDict, skipall, SkipDict, skipDict, get_geotable, extract_plot_coords, borders, remove_polyareas!, floattype, npolyareas
+using CountriesBorders: possible_selector_values, valid_column_names, mergeSkipDict, validate_skipDict, skipall, SkipDict, skipDict, get_geotable, extract_plot_coords, borders, remove_polyareas!, floattype, npolyareas, to_cart_point
 using CountriesBorders.GeoTablesConversion: POINT_CART
 using Meshes
 using CoordRefSystems
 using Test
 using Unitful
+
+@test to_cart_point(LatLon(0, 0)) isa POINT_CART{Float32}
 
 example1 = extract_countries(;continent = "europe", admin="-russia")
 example2 = extract_countries(;admin="-russia", continent = "europe")

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,5 +1,5 @@
 using CountriesBorders
-using CountriesBorders: possible_selector_values, valid_column_names, mergeSkipDict, validate_skipDict, skipall, SkipDict, skipDict, get_geotable, extract_plot_coords, borders, remove_polyareas!, floattype, npolyareas, to_cart_point
+using CountriesBorders: possible_selector_values, valid_column_names, mergeSkipDict, validate_skipDict, skipall, SkipDict, skipDict, get_geotable, extract_plot_coords, borders, remove_polyareas!, floattype, npolyareas, to_cart_point, change_geometry, Cartesian, in_exit_early
 using CountriesBorders.GeoTablesConversion: POINT_CART
 using Meshes
 using CoordRefSystems
@@ -7,6 +7,9 @@ using Test
 using Unitful
 
 @test to_cart_point(LatLon(0, 0)) isa POINT_CART{Float32}
+poly = rand(PolyArea; crs = LatLon) |> change_geometry(Cartesian)
+@test in_exit_early(centroid(poly), poly, boundingbox(poly))
+
 
 example1 = extract_countries(;continent = "europe", admin="-russia")
 example2 = extract_countries(;admin="-russia", continent = "europe")

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -32,10 +32,18 @@ example3 = extract_countries(;subregion = "*europe; -eastern europe")
         LatLon(78.222, 15.652) # Svalbard Museum
     ]
 
+    # We don't use the const from the package to have more coverage
+    Skip_noncontinental_eu =  [
+        SkipFromAdmin("France", 1) # This skips Guyana
+        SkipFromAdmin("Norway", [
+            1, 3, 4 # Continental Norway is the 2nd PolyArea only
+        ])
+    ] |> skipDict
+
     dmn_excluded = extract_countries("italy; spain; france; norway"; skip_areas = [
         ("Italy", 2)
         "Spain"
-        SKIP_NONCONTINENTAL_EU
+        Skip_noncontinental_eu
     ])
     @test all(in(dmn_excluded), included_cities)
     @test all(!in(dmn_excluded), excluded_cities)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -7,7 +7,9 @@ using Test
 using Unitful
 
 @test to_cart_point(LatLon(0, 0)) isa POINT_CART{Float32}
-poly = rand(PolyArea; crs = LatLon) |> change_geometry(Cartesian)
+poly = map([(-1,-1), (-1, 1), (1, 1), (1, -1)]) do p 
+    LatLon(p...) |> Point
+end |> PolyArea |> change_geometry(Cartesian)
 @test in_exit_early(centroid(poly), poly, boundingbox(poly))
 
 

--- a/test/meshes_interface.jl
+++ b/test/meshes_interface.jl
@@ -1,7 +1,7 @@
 @testsnippet InterfacesSetup begin
     using Meshes
     using CountriesBorders
-    using CountriesBorders: borders, bboxes, polyareas
+    using CountriesBorders: borders, bboxes, polyareas, floattype
     using CoordRefSystems
     using Test
 end
@@ -44,3 +44,19 @@ end
     dmn = extract_countries(;continent = "Europe")
     @test collect(bboxes(dmn)) == bboxes(collect(polyareas(dmn)))
 end
+
+@testitem "floattype" setup=[InterfacesSetup] begin
+    dmn = extract_countries(;continent = "Europe")
+    cb = element(dmn, 1)
+    brdlat = borders(LatLon, cb)
+    brdcart = borders(Cartesian, cb)
+    p = rand(Point; crs = LatLon)
+    ll = rand(LatLon)
+    @test all((dmn, cb, brdlat, brdcart)) do el
+        floattype(el) == Float32
+    end
+    @test all((p, ll)) do el
+        floattype(el) == Float64
+    end
+end
+

--- a/test/meshes_interface.jl
+++ b/test/meshes_interface.jl
@@ -26,3 +26,16 @@ end
     russia = extract_countries("russia")
     @test all(!in(russia), [LatLon(lat, -100) for lat in -30:.01:75])
 end
+
+@testitem "in_exit_early" setup=[InterfacesSetup] begin
+    using CountriesBorders: in_exit_early, Cartesian, borders, DOMAIN, to_cart_point
+    dmn = extract_countries("*")
+    # Add consistency checks with the standard `in` method not doing exit early
+    _in(p, cb::CountryBorder) = in(to_cart_point(p), borders(Cartesian, cb))
+    _in(p, dm::DOMAIN) = any(_in(p, e) for e in dm)
+
+    @test all(1:100) do _
+        p = rand(Point; crs = LatLon)
+        _in(p, dmn) == in(p, dmn)
+    end
+end

--- a/test/meshes_interface.jl
+++ b/test/meshes_interface.jl
@@ -1,7 +1,7 @@
 @testsnippet InterfacesSetup begin
     using Meshes
     using CountriesBorders
-    using CountriesBorders: borders
+    using CountriesBorders: borders, bboxes, polyareas
     using CoordRefSystems
     using Test
 end
@@ -38,4 +38,9 @@ end
         p = rand(Point; crs = LatLon)
         _in(p, dmn) == in(p, dmn)
     end
+end
+
+@testitem "polyareas and bboxes" setup=[InterfacesSetup] begin
+    dmn = extract_countries(;continent = "Europe")
+    @test collect(bboxes(dmn)) == bboxes(collect(polyareas(dmn)))
 end


### PR DESCRIPTION
This PR adds a new field to `CountryBorder` and a new methodology to check for inclusion using the `p in dmn` method.
Each `CountryBorder` now stores the Cartesian boundingbox for each of its `PolyArea`s and will pre-filter points based on the boundingboxes to significantly limit points for which to actually check inclusion in the polygons representing the country's borders.

This new `in` method is actually implemented in the `in_exit_early` internal functions which can now be used in GeoGrids.

The new methodology brings a speed up factor of 20x-40x, as seen from the benchmarks below:

```julia
using CountriesBorders
using CoordRefSystems
using PrettyChairmarks

grid = [LatLon(lat, lon) for lat in -90:90, lon in -180:180]

all = extract_countries("*")
europe = extract_countries(;continent = "Europe")
france = extract_countries("France")

f(dmn, pts) = filter(in(dmn), pts)

@bs (all, grid) f(_...)
@bs (europe, grid) f(_...)
@bs (france, grid) f(_...)
```

which brings the following times on julia 1.11 on Windows:

## Before PR
```julia

#### @bs (all, grid) f(_...) ####
Chairmarks.Benchmark: 1 sample with 1 evaluation.
 Single result which took 2.660 s (0.00% GC) to evaluate,
 with a memory estimate of 1.33 MiB, over 5 allocations.

#### @bs (europe, grid) f(_...) ####
Chairmarks.Benchmark: 1 sample with 1 evaluation.
 Single result which took 542.060 ms (0.00% GC) to evaluate,
 with a memory estimate of 1.05 MiB, over 5 allocations.

#### @bs (france, grid) f(_...) ####
Chairmarks.Benchmark: 6 samples with 1 evaluation.
 Range (min … max):  17.484 ms … 23.179 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     18.236 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   18.908 ms ±  2.121 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █   █ █ ██                                                █  
  █▁▁▁█▁█▁██▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  17.5 ms         Histogram: frequency by time        23.2 ms <

 Memory estimate: 1022.28 KiB, allocs estimate: 4.
```

## After PR
```julia
#### @bs (all, grid) f(_...) ####
Chairmarks.Benchmark: 2 samples with 1 evaluation.
 Range (min … max):   93.918 ms … 119.885 ms  ┊ GC (min … max):  0.00% … 24.64%
 Time  (median):     106.901 ms               ┊ GC (median):    12.32%
 Time  (mean ± σ):   106.901 ms ±  18.362 ms  ┊ GC (mean ± σ):  12.32% ± 17.42%

  █                                                           █
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  93.9 ms          Histogram: frequency by time          120 ms <

 Memory estimate: 1.33 MiB, allocs estimate: 5.

#### @bs (europe, grid) f(_...) ####
Chairmarks.Benchmark: 5 samples with 1 evaluation.
 Range (min … max):  19.609 ms … 25.120 ms  ┊ GC (min … max): 0.00% … 17.12%
 Time  (median):     20.540 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   21.214 ms ±  2.236 ms  ┊ GC (mean ± σ):  3.42% ±  7.66%

  █  █     █   █                                            █
  █▁▁█▁▁▁▁▁█▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  19.6 ms         Histogram: frequency by time        25.1 ms <

 Memory estimate: 1.05 MiB, allocs estimate: 5.


#### @bs (france, grid) f(_...) ####
Chairmarks.Benchmark: 183 samples with 1 evaluation.
 Range (min … max):  375.600 μs …   3.176 ms  ┊ GC (min … max): 0.00% … 85.23%
 Time  (median):     423.000 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   507.669 μs ± 275.846 μs  ┊ GC (mean ± σ):  7.26% ± 19.33%

  ▁ █▄▆▂
  ██████▄▆▇▄▁▆▁▁▁▁▁▁▁▄▁▁▁▁▁▄▁▁▁▁▁▁▁▁▁▁▄▁▁▄▄▁▄▄▆▆▆▁▆▄▁▄▁▆▁▁▄▆▁▁▄ ▄
  376 μs        Histogram: log(frequency) by time       1.15 ms <

 Memory estimate: 1022.28 KiB, allocs estimate: 4.
```
