### PR TITLE
refactor and expand latlon/cart conversion helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.6] - 2025-03-20
+This release has some breaking changes to internal functions, but as these were not exported it is not considered a breaking release
+
+### Changed
+- Some refactoring of internal code and breaking changes to the following non-exported internal functions to make them more flexible:
+    - `latlon_geometry`
+    - `cartesian_geometry`
+    - `change_geometry`
+    - `to_cart_point`
+
+### Added
+New internal function `to_latlon_point` which mirrors `to_cart_point` but for the output in LatLon crs.
+
+## [0.4.5] - 2025-03-08
 
 ### Changed
 - The `CountryBorder` type now has a new field `bboxes` which contains the bounding boxes (Cartesian) of each polyarea within the country. This is used to speed up the inclusion test in the new custom `in` implementation using the `in_exit_early` internal function. This brings speedups of ~20x compared to the previous implementation.

--- a/src/CountriesBorders.jl
+++ b/src/CountriesBorders.jl
@@ -7,17 +7,18 @@ using GeoInterface
 using Tables
 using GeoJSON
 using Artifacts
-using Unitful: Unitful, ustrip
+using Unitful: Unitful, ustrip, @u_str
 using PrecompileTools
 using NaturalEarth: NaturalEarth, naturalearth
 using CoordRefSystems
 using CoordRefSystems: Deg, Met
 
 export extract_countries, SKIP_NONCONTINENTAL_EU, SkipFromAdmin, SimpleLatLon, LatLon, Point
-export CountryBorder
-export extract_plot_coords
 
-include("conversions.jl")
+include("GeoTablesConversion.jl")
+using .GeoTablesConversion
+using .GeoTablesConversion: VALID_POINT, LATLON, CART, VALID_RING, GSET, POLY_CART, BOX_CART, POINT_LATLON, POINT_CART, MULTI_CART
+export CountryBorder
 
 const SimpleLatLon = LatLon
 const RegionBorders{T} = Union{CountryBorder{T}, DOMAIN{T}}
@@ -27,6 +28,7 @@ include("meshes_interface.jl")
 include("skip_polyarea.jl")
 include("implementation.jl")
 include("plot_coordinates.jl")
+export extract_plot_coords
 
 @compile_workload begin
     table = get_geotable()

--- a/src/GeoTablesConversion.jl
+++ b/src/GeoTablesConversion.jl
@@ -11,11 +11,9 @@ module GeoTablesConversion
     using Unitful: °
 
     export CountryBorder, DOMAIN, remove_polyareas!
-    export change_geometry, latlon_geometry, cartesian_geometry
+    export change_geometry, latlon_geometry, cartesian_geometry, to_cart_point, to_latlon_point, floattype
 
     include("main_type.jl")
+    include("helpers.jl")
     include("conversion_utils.jl")
 end
-
-using .GeoTablesConversion
-using .GeoTablesConversion: VALID_POINT, LATLON, CART, VALID_RING, GSET, POLY_CART, BOX_CART, POINT_LATLON, POINT_CART, MULTI_CART

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -37,6 +37,11 @@ The second method simply returns a function that applies the conversion with the
 ## Returns
 - The converted geometry, with points of type `POINT_CART{T}`.
 """
+function cartesian_geometry(T::Type{<:Real}, b::Union{BOX_LATLON, BOX_CART})
+    b isa BOX_CART{T} && return b
+    f = to_cart_point(T)
+    return BOX_CART{T}(f(b.min), f(b.max))
+end
 function cartesian_geometry(T::Type{<:Real}, ring::Union{RING_CART, RING_LATLON})
     ring isa RING_CART{T} && return ring
     map(to_cart_point(T), vertices(ring)) |> Ring
@@ -68,6 +73,11 @@ The second method simply returns a function that applies the conversion with the
 - The converted geometry, with points of type `POINT_LATLON{T}`.
 
 """
+function latlon_geometry(T::Type{<:Real}, b::Union{BOX_LATLON, BOX_CART})
+    b isa BOX_LATLON{T} && return b
+    f = to_latlon_point(T)
+    return BOX_LATLON{T}(f(b.min), f(b.max))
+end
 function latlon_geometry(T::Type{<:Real}, ring::Union{RING_CART, RING_LATLON})
     ring isa RING_LATLON{T} && return ring
     map(to_latlon_point(T), vertices(ring)) |> Ring

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -1,0 +1,104 @@
+floattype(::Type{<:CountryBorder{T}}) where {T} = T
+floattype(::Type{<:DOMAIN{T}}) where {T} = T
+floattype(::Type{<:Geometry{🌐,LATLON{T}}}) where T = T
+floattype(::Type{<:Geometry{𝔼{2},CART{T}}}) where T = T
+floattype(::Type{<:Union{LATLON{T}, CART{T}}}) where T = T
+floattype(::Type{<:VALID_POINT{T}}) where T = T
+floattype(x) = floattype(typeof(x))
+
+to_cart_point(T::Type{<:Real}, p::POINT_CART) = convert(POINT_CART{T}, p)
+to_cart_point(T::Type{<:Real}, p::POINT_LATLON) = to_cart_point(T, Meshes.flat(p))
+to_cart_point(T::Type{<:Real}, p::Union{LATLON, CART}) = to_cart_point(T, Point(p))
+to_cart_point(T::Type{<:Real}) = Base.Fix1(to_cart_point, T)
+to_cart_point(x) = to_cart_point(floattype(x), x)
+
+to_latlon_point(T::Type{<:Real}, p::POINT_LATLON) = convert(POINT_LATLON{T}, p)
+function to_latlon_point(T::Type{<:Real}, p::POINT_CART) 
+    lon, lat = CoordRefSystems.raw(coords(p))
+    return LATLON{T}(lat * u"°", lon * u"°") |> Point
+end
+to_latlon_point(T::Type{<:Real}, p::Union{LATLON, CART}) = to_latlon_point(T, Point(p))
+to_latlon_point(T::Type{<:Real}) = Base.Fix1(to_latlon_point, T)
+to_latlon_point(x) = to_latlon_point(floattype(x), x)
+
+
+"""
+    cartesian_geometry([T::Type{<:Real}, ] geom)
+    cartesian_geometry(T::Type{<:Real})
+
+Convert geometries from LatLon to Cartesian coordinate systems, optionally changing the underlying machine type of the points to `T`
+
+The second method simply returns a function that applies the conversion with the provided machine type to any geometry.
+
+## Arguments
+- `T::Type{<:Real}`: The desired machine type of the points in the output geometry. If not provided, it will default to the machine type of the input geometry.
+- `geom`: The geometry to convert, which can be an arbitrary Geometry either in LatLon{WGS84Latest} or Cartesian2D{WGS84Latest} coordinates.
+
+## Returns
+- The converted geometry, with points of type `POINT_CART{T}`.
+"""
+function cartesian_geometry(T::Type{<:Real}, ring::Union{RING_CART, RING_LATLON})
+    ring isa RING_CART{T} && return ring
+    map(to_cart_point(T), vertices(ring)) |> Ring
+end
+function cartesian_geometry(T::Type{<:Real}, poly::Union{POLY_LATLON, POLY_CART})
+    poly isa POLY_CART{T} && return poly
+    map(cartesian_geometry(T), rings(poly)) |> splat(PolyArea)
+end
+function cartesian_geometry(T::Type{<:Real}, multi::Union{MULTI_LATLON, MULTI_CART})
+    multi isa MULTI_CART{T} && return multi
+    map(cartesian_geometry(T), parent(multi)) |> Multi
+end
+cartesian_geometry(T::Type{<:Real}) = Base.Fix1(cartesian_geometry, T)
+cartesian_geometry(x) = cartesian_geometry(floattype(x), x)
+
+"""
+    latlon_geometry([T::Type{<:Real}, ] geom)
+    latlon_geometry(T::Type{<:Real})
+
+Convert geometries from Cartesian to LatLon coordinate systems, optionally changing the underlying machine type of the points to `T`
+
+The second method simply returns a function that applies the conversion with the provided machine type to any geometry. 
+
+## Arguments
+- `T::Type{<:Real}`: The desired machine type of the points in the output geometry. If not provided, it will default to the machine type of the input geometry.
+- `geom`: The geometry to convert, which can be an arbitrary Geometry either in LatLon{WGS84Latest} or Cartesian2D{WGS84Latest} coordinates.
+
+## Returns
+- The converted geometry, with points of type `POINT_LATLON{T}`.
+
+"""
+function latlon_geometry(T::Type{<:Real}, ring::Union{RING_CART, RING_LATLON})
+    ring isa RING_LATLON{T} && return ring
+    map(to_latlon_point(T), vertices(ring)) |> Ring
+end
+function latlon_geometry(T::Type{<:Real}, poly::Union{POLY_LATLON, POLY_CART})
+    poly isa POLY_LATLON{T} && return poly
+    map(latlon_geometry(T), rings(poly)) |> splat(PolyArea)
+end
+function latlon_geometry(T::Type{<:Real}, multi::Union{MULTI_LATLON, MULTI_CART})
+    multi isa MULTI_LATLON{T} && return multi
+    map(latlon_geometry(T), parent(multi)) |> Multi
+end
+latlon_geometry(T::Type{<:Real}) = Base.Fix1(latlon_geometry, T)
+latlon_geometry(x) = latlon_geometry(floattype(x), x)
+
+
+"""
+    change_geometry(crs::Type{Cartesian}[, T::Type{<:Real}], x)
+    change_geometry(crs::Type{LatLon}[, T::Type{<:Real}], x)
+    change_geometry(crs[, T::Type{<:Real}])
+
+Change the underlying CRS of a geometry from Cartesian to LatLon (or vice versa) and optionally change the underlying machine type of the points to `T`.
+
+The last method only taking `Cartesian` or `LatLon` as input (and optionally the machine type `T`) simply returns a function that will apply the provided CRS (and optionally `T`) to any geometry used as input.
+
+!!! note
+    This method simply forwards the input to either the `cartesian_geometry` or `latlon_geometry` function based on the value of `crs`.
+"""
+change_geometry(::Type{Cartesian}, T::Type{<:Real}, x) = cartesian_geometry(T, x)
+change_geometry(::Type{LatLon}, T::Type{<:Real}, x) = latlon_geometry(T, x)
+change_geometry(crs::Union{Type{Cartesian}, Type{LatLon}}, x) = change_geometry(crs, floattype(x), x)
+change_geometry(crs::Union{Type{Cartesian}, Type{LatLon}}) = Base.Fix1(change_geometry, crs)
+change_geometry(::Type{Cartesian}, ::Type{T}) where {T <: Real} = x -> change_geometry(Cartesian, T, x)
+change_geometry(::Type{LatLon}, ::Type{T}) where {T <: Real} = x -> change_geometry(LatLon, T, x)

--- a/src/meshes_interface.jl
+++ b/src/meshes_interface.jl
@@ -2,13 +2,6 @@
 const VALID_CRS = Type{<:Union{LatLon, Cartesian}}
 
 # These are methods which are not really part of meshes
-floattype(::Type{<:CountryBorder{T}}) where {T} = T
-floattype(::Type{<:DOMAIN{T}}) where {T} = T
-floattype(::Type{<:Geometry{🌐,LATLON{T}}}) where T = T
-floattype(::Type{<:Geometry{𝔼{2},CART{T}}}) where T = T
-floattype(::Type{<:Union{LATLON{T}, CART{T}}}) where T = T
-floattype(::Type{<:VALID_POINT{T}}) where T = T
-floattype(x) = floattype(typeof(x))
 
 borders(::Type{LatLon}, cb::CountryBorder) = cb.latlon
 borders(::Type{Cartesian}, cb::CountryBorder) = cb.cart
@@ -95,7 +88,7 @@ This function is basically pre-filtering points by checking inclusion in the bou
 """
 function in_exit_early(p, polys, bboxes)
     T = first(polys) |> floattype
-    p = to_cart_point(p, T)
+    p = to_cart_point(T, p)
     for (poly, box) in zip(polys, bboxes)
         p in box || continue
         p in poly && return true
@@ -104,10 +97,6 @@ function in_exit_early(p, polys, bboxes)
 end
 # This is a catchall method for extension for other types
 in_exit_early(p, x) = in_exit_early(p, polyareas(x), bboxes(x))
-
-to_cart_point(p::POINT_CART, T::Type{<:Real} = Float32) = convert(POINT_CART{T}, p)
-to_cart_point(p::POINT_LATLON, T::Type{<:Real} = Float32) = to_cart_point(Meshes.flat(p), T)
-to_cart_point(p::Union{LATLON, CART}, T::Type{<:Real} = Float32) = to_cart_point(Point(p), T)
 
 Base.in(p::VALID_POINT, cb::CountryBorder) = in_exit_early(p, cb)
 Base.in(p::LATLON, dmn::Union{DOMAIN, CountryBorder}) = in(Point(p), dmn)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -107,7 +107,7 @@ end
     merge!(sfa, SkipFromAdmin("France", 2), SkipFromAdmin("France", 3))
     @test sfb.idxs == sfa.idxs
 
-    @test to_cart_point(LatLon(0, 0)) isa POINT_CART{Float32}
+    @test to_cart_point(LatLon(0, 0)) isa POINT_CART{Float64}
     poly = map([(-1,-1), (-1, 1), (1, 1), (1, -1)]) do p 
         LatLon(p...) |> Point
     end |> PolyArea |> change_geometry(Cartesian)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,7 +1,7 @@
 @testsnippet setup_basic begin
     using CountriesBorders
-    using CountriesBorders: possible_selector_values, valid_column_names, mergeSkipDict, validate_skipDict, skipall, SkipDict, skipDict, get_geotable, extract_plot_coords, borders, remove_polyareas!, floattype, to_cart_point, change_geometry, Cartesian, in_exit_early, polyareas, INSERT_NAN
-    using CountriesBorders.GeoTablesConversion: POINT_CART, cartesian_geometry, latlon_geometry, change_geometry
+    using CountriesBorders: possible_selector_values, valid_column_names, mergeSkipDict, validate_skipDict, skipall, SkipDict, skipDict, get_geotable, extract_plot_coords, borders, remove_polyareas!, floattype, to_cart_point, change_geometry, Cartesian, in_exit_early, polyareas, INSERT_NAN, latlon_geometry, cartesian_geometry, floattype, to_latlon_point
+    using CountriesBorders.GeoTablesConversion: POINT_CART, POINT_LATLON, POLY_LATLON, POLY_CART, BOX_LATLON, BOX_CART
     using Meshes
     using CoordRefSystems
     using Test
@@ -177,6 +177,21 @@ end
     multi_cartesian = Multi([pa_cartesian])
     multi_latlon = Multi([pa_latlon])
 
+    # Test the Box conversion
+    box_latlon = Box(
+        Point(LatLon(-10°, -10°)),
+        Point(LatLon(10°, 10°))
+    )
+
+    @test box_latlon |> change_geometry(Cartesian) isa BOX_CART{Float64}
+    @test box_latlon |> change_geometry(Cartesian, Float32) |> change_geometry(LatLon) isa BOX_LATLON{Float32}
+
+    @test pa_latlon |> change_geometry(LatLon, Float32) isa POLY_LATLON{Float32}
+    @test pa_latlon |> change_geometry(Cartesian, Float32) isa POLY_CART{Float32}
+
+    @test pa_latlon |> cartesian_geometry isa POLY_CART{Float64}
+    @test pa_cartesian |> latlon_geometry isa POLY_LATLON{Float64}
+
     @test pa_latlon |> change_geometry(Cartesian) |> change_geometry(LatLon) == pa_latlon
     @test pa_latlon |> change_geometry(LatLon) == pa_latlon
     @test pa_cartesian |> change_geometry(LatLon) |> change_geometry(Cartesian) == pa_cartesian
@@ -186,4 +201,6 @@ end
 
     @test multi_cartesian |> change_geometry(LatLon) == multi_latlon
     @test multi_latlon |> change_geometry(Cartesian) == multi_cartesian
+
+    @test rand(LatLon) |> to_latlon_point isa POINT_LATLON{Float64}
 end

--- a/test/meshes_interface.jl
+++ b/test/meshes_interface.jl
@@ -31,7 +31,7 @@ end
     using CountriesBorders: in_exit_early, Cartesian, borders, DOMAIN, to_cart_point
     dmn = extract_countries("*")
     # Add consistency checks with the standard `in` method not doing exit early
-    _in(p, cb::CountryBorder) = in(to_cart_point(p), borders(Cartesian, cb))
+    _in(p, cb::CountryBorder) = in(to_cart_point(floattype(cb), p), borders(Cartesian, cb))
     _in(p, dm::DOMAIN) = any(_in(p, e) for e in dm)
 
     @test all(1:100) do _


### PR DESCRIPTION
This PR has some breaking changes to internal functions, but as these were not exported it is not considered a breaking release

### Changed
- Some refactoring of internal code and breaking changes to the following non-exported internal functions to make them more flexible:
    - `latlon_geometry`
    - `cartesian_geometry`
    - `change_geometry`
    - `to_cart_point`

### Added
New internal function `to_latlon_point` which mirrors `to_cart_point` but for the output in LatLon crs.