### PR TITLE
make extract_plot_coords! works better with vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Added a method for `extract_plot_coords` to make it work automatically with a vector of valid points.
+
 ## [0.4.6] - 2025-03-20
 This release has some breaking changes to internal functions, but as these were not exported it is not considered a breaking release
 

--- a/src/plot_coordinates.jl
+++ b/src/plot_coordinates.jl
@@ -7,6 +7,8 @@ Defaults to `true`
 """
 const INSERT_NAN = Base.ScopedValues.ScopedValue{Bool}(true)
 
+const VALID_PLOT_COORD = Union{LATLON, CART, VALID_POINT}
+
 # Extracting lat/lon coordaintes of the borders
 function extract_plot_coords!(lat::Vector{T}, lon::Vector{T}, ll::LATLON) where T <: Number
     f(x) = convert(T, ustrip(x))
@@ -22,7 +24,16 @@ function extract_plot_coords!(lat::Vector{T}, lon::Vector{T}, c::CART) where T <
 end
 extract_plot_coords!(lat, lon, p::VALID_POINT) = extract_plot_coords!(lat, lon, coords(p))
 
-function extract_plot_coords!(lat, lon, els::Vector)
+function extract_plot_coords!(lat, lon, els::AbstractVector{<:VALID_PLOT_COORD})
+    if INSERT_NAN[] && !isempty(lat) && !isempty(lon)
+        extract_plot_coords!(lat, lon, LatLon(NaN, NaN))
+    end
+    for el in els
+        extract_plot_coords!(lat, lon, el)
+    end
+    return nothing
+end
+function extract_plot_coords!(lat, lon, els::AbstractVector)
     for el in els
         extract_plot_coords!(lat, lon, el)
     end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -167,6 +167,18 @@ end
         f(x,y) = (isnan(x) && isnan(y)) || x == y
         @test all(x -> f(x...), zip(a1, a2))
     end
+
+    # We test that it also works with vector of points or vector or vectors of points
+    lls = extract_plot_coords(rand(Point, 3; crs = LatLon))
+    @test count(isnan, lls.lat) == 0
+
+    lls = extract_plot_coords([rand(Point, 3; crs = LatLon) for _ in 1:2])
+    @test count(isnan, lls.lat) == 1
+
+    lls = Base.ScopedValues.with(INSERT_NAN => false) do
+        extract_plot_coords([rand(Point, 3; crs = LatLon) for _ in 1:2])
+    end
+    @test count(isnan, lls.lat) == 0
 end
 
 @testitem "Cartesian LatLon conversion" setup=[setup_basic] begin


### PR DESCRIPTION
This PR adds a method for `extract_plot_coords` to make it work automatically with a vector of valid points.