### PR TITLE
Oversample distant points in extract_plot_coords

### DIFF
--- a/src/GeoTablesConversion.jl
+++ b/src/GeoTablesConversion.jl
@@ -11,7 +11,7 @@ module GeoTablesConversion
     using Unitful: °
 
     export CountryBorder, DOMAIN, remove_polyareas!
-    export change_geometry, latlon_geometry, cartesian_geometry, to_cart_point, to_latlon_point, floattype
+    export change_geometry, latlon_geometry, cartesian_geometry, to_cart_point, to_latlon_point, floattype, to_raw_coords
 
     include("main_type.jl")
     include("helpers.jl")

--- a/src/conversion_utils.jl
+++ b/src/conversion_utils.jl
@@ -30,7 +30,7 @@ SOFTWARE.
 
 # This function assumes that a set of points represent a valid GeoJSON geometry (which is already split to avoid antimeridian problems) and simply makes sure that the sign of the longitude at 180° is consistent with the remaining points in the ring
 function fix_antimeridian_sign!(points::Vector{<:POINT_LATLON})
-    cond(p) = abs(coords(p).lon) ≈ 180u"°"
+    cond(p) = abs(coords(p).lon) == 180u"°"
     getsign(p) = sign(coords(p).lon)
     any(cond, points) || return
     signpoint = points[findfirst(!cond, points)]

--- a/src/conversion_utils.jl
+++ b/src/conversion_utils.jl
@@ -28,6 +28,24 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 =#
 
+# This function assumes that a set of points represent a valid GeoJSON geometry (which is already split to avoid antimeridian problems) and simply makes sure that the sign of the longitude at 180° is consistent with the remaining points in the ring
+function fix_antimeridian_sign!(points::Vector{<:POINT_LATLON})
+    cond(p) = abs(coords(p).lon) ≈ 180u"°"
+    getsign(p) = sign(coords(p).lon)
+    any(cond, points) || return
+    signpoint = points[findfirst(!cond, points)]
+    s = getsign(signpoint)
+    for (i, p) in enumerate(points)
+        if cond(p)
+            c = coords(p)
+            points[i] = LatLon(c.lat, copysign(c.lon, s)) |> Point
+        else
+            s = getsign(p) # We use the sign of the latest valid point as relevant for the sign. This is mostly needed for antarctica which spans all latitudes
+        end
+    end
+    return nothing
+end
+
 # The commented out lines below are those not needed for parsing the specific file of countries borders. These might be enabled in the future if needed.
 
 # Part from https://github.com/JuliaEarth/GeoIO.jl/blob/8c0eb84223ecf8a8601850f8b7cc27f81a18d68c/src/conversion.jl.
@@ -42,6 +60,7 @@ function tochain(geom)
     while first(points) == last(points) && length(points) ≥ 2
       pop!(points)
     end
+    fix_antimeridian_sign!(points)
     Ring(points)
   end
 end

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -6,6 +6,9 @@ floattype(::Type{<:Union{LATLON{T}, CART{T}}}) where T = T
 floattype(::Type{<:VALID_POINT{T}}) where T = T
 floattype(x) = floattype(typeof(x))
 
+to_raw_coords(c::Union{LATLON, CART}) = CoordRefSystems.raw(c)
+to_raw_coords(p::VALID_POINT) = to_raw_coords(coords(p))
+
 to_cart_point(T::Type{<:Real}, p::POINT_CART) = convert(POINT_CART{T}, p)
 to_cart_point(T::Type{<:Real}, p::POINT_LATLON) = to_cart_point(T, Meshes.flat(p))
 to_cart_point(T::Type{<:Real}, p::Union{LATLON, CART}) = to_cart_point(T, Point(p))
@@ -14,7 +17,7 @@ to_cart_point(x) = to_cart_point(floattype(x), x)
 
 to_latlon_point(T::Type{<:Real}, p::POINT_LATLON) = convert(POINT_LATLON{T}, p)
 function to_latlon_point(T::Type{<:Real}, p::POINT_CART) 
-    lon, lat = CoordRefSystems.raw(coords(p))
+    lon, lat = to_raw_coords(p)
     return LATLON{T}(lat * u"°", lon * u"°") |> Point
 end
 to_latlon_point(T::Type{<:Real}, p::Union{LATLON, CART}) = to_latlon_point(T, Point(p))

--- a/src/meshes_interface.jl
+++ b/src/meshes_interface.jl
@@ -15,10 +15,24 @@ polyareas(x) = polyareas(borders(Cartesian, x))
 polyareas(v::Vector{<:POLY_CART}) = v
 polyareas(x::MULTI_CART) = parent(x)
 polyareas(x::POLY_CART) = (x,)
+function polyareas(b::BOX_CART)
+	lo, hi = extrema(b) .|> to_raw_coords
+    lo_lon, lo_lat = lo
+    hi_lon, hi_lat = hi
+    f = to_cart_point
+    p = Ring([
+        f(LatLon(hi_lat, lo_lon)),
+        f(LatLon(hi_lat, hi_lon)),
+        f(LatLon(lo_lat, hi_lon)),
+        f(LatLon(lo_lat, lo_lon)),
+    ]) |> PolyArea
+    return (p, )
+end
 polyareas(dmn::DOMAIN) = Iterators.flatten(polyareas(el) for el in dmn)
 
 # This should return the cartesian bounding boxes for the polyareas of x, mostly to be used with in_exit_early
 bboxes(x) = map(boundingbox, polyareas(x))
+bboxes(b::BOX_CART) = (b,)
 bboxes(cb::CountryBorder) = cb.bboxes
 bboxes(dmn::DOMAIN) = Iterators.flatten(bboxes(el) for el in dmn)
 

--- a/src/plot_coordinates.jl
+++ b/src/plot_coordinates.jl
@@ -28,7 +28,19 @@ function line_plot_coords(start, stop)
     end
     nrm = hypot(Δlat, Δlon)
     should_split = nrm > 10
-    min_length = should_split ? 10 : (200 / max(abs(lat1), abs(lat2), 10))
+    min_length = if should_split 
+        10 
+    else 
+        maxlat = max(abs(lat1), abs(lat2))
+        val = (100 / min(maxlat, 10)) 
+        if maxlat > 65
+            val /= 2
+        end
+        if maxlat > 80
+            val /= 2
+        end
+        val
+    end
     npts = ceil(Int, nrm / min_length)
     lat_step = Δlat / npts
     lon_step = Δlon / npts

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -115,6 +115,7 @@ end
 
     # We test that 50m resolution has more polygons than the default 110m one
     @test length(get_geotable(;resolution = 50).geometry) > length(get_geotable().geometry)
+    @test length(get_geotable(;resolution = 10).geometry) > length(get_geotable(;resolution = 50).geometry)
 
     italy = extract_countries("italy") |> only
     npolyareas(x) = length(polyareas(x))

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -141,6 +141,8 @@ end
 
 @testitem "Extract plot coords" setup=[setup_basic] begin
 # We test that extract_plot_coords gives first lat and then lon
+    using CountriesBorders: PLOT_STRAIGHT_LINES
+
     dmn = extract_countries("italy")
     @test extract_plot_coords(dmn) isa @NamedTuple{lat::Vector{Float32}, lon::Vector{Float32}}
     ps = rand(Point, 100; crs = LatLon)
@@ -179,6 +181,31 @@ end
         extract_plot_coords([rand(Point, 3; crs = LatLon) for _ in 1:2])
     end
     @test count(isnan, lls.lat) == 0
+
+    # We test that the extract_plot_coords increase the number of points for very long lines
+    b = Box(
+        to_cart_point(LatLon(-30, -180)),
+        to_cart_point(LatLon(30, 180)),
+    )
+    poly = polyareas(b) |> first
+    Base.ScopedValues.with(PLOT_STRAIGHT_LINES => true) do
+        plc = extract_plot_coords(poly)
+        # The +1 is because extract replicates the first point
+        @test length(plc.lat) > length(vertices(poly)) + 1
+    end
+
+    Base.ScopedValues.with(PLOT_STRAIGHT_LINES => false) do
+        plc = extract_plot_coords(poly)
+        @test length(plc.lat) == length(vertices(poly)) + 1
+    end
+
+    # We test the copy_first_point keyword when providing directly a vector of points
+    r = rings(poly) |> first
+    vs = vertices(r)
+    Base.ScopedValues.with(PLOT_STRAIGHT_LINES => false) do
+        @test length(extract_plot_coords(vs).lat) == length(vs)
+        @test length(extract_plot_coords(vs; copy_first_point = true).lat) == length(vs) + 1
+    end
 end
 
 @testitem "Cartesian LatLon conversion" setup=[setup_basic] begin

--- a/test/extensions.jl
+++ b/test/extensions.jl
@@ -31,6 +31,7 @@ end
 end
 
 @testitem "Points" setup = [setup_extensions] begin
+    using CountriesBorders: PLOT_STRAIGHT_LINES
     cities = [
         SimpleLatLon(41.9, 12.49) # Rome
         SimpleLatLon(39.217, 9.113) # Cagliari
@@ -38,7 +39,9 @@ end
         SimpleLatLon(59.913, 10.738) # Oslo
     ]
 
-    sg = cities |> scattergeo
+    sg = Base.ScopedValues.with(PLOT_STRAIGHT_LINES => false) do
+        cities |> scattergeo
+    end
 
     @test sg.lat == map(x -> x.lat |> ustrip |> Float32, cities)
     @test sg.lon == map(x -> x.lon |> ustrip |> Float32, cities)

--- a/test/meshes_interface.jl
+++ b/test/meshes_interface.jl
@@ -1,7 +1,7 @@
 @testsnippet InterfacesSetup begin
     using Meshes
     using CountriesBorders
-    using CountriesBorders: borders, bboxes, polyareas, floattype
+    using CountriesBorders: borders, bboxes, polyareas, floattype, to_cart_point
     using CoordRefSystems
     using Test
 end
@@ -43,6 +43,12 @@ end
 @testitem "polyareas and bboxes" setup=[InterfacesSetup] begin
     dmn = extract_countries(;continent = "Europe")
     @test collect(bboxes(dmn)) == bboxes(collect(polyareas(dmn)))
+
+    b = Box(
+        to_cart_point(LatLon(-30, -180)),
+        to_cart_point(LatLon(30, 180)),
+    )
+    @test bboxes(b) |> first === b
 end
 
 @testitem "floattype" setup=[InterfacesSetup] begin


### PR DESCRIPTION
This PR adds a new ScopedValue (`PLOT_STRAIGHT_LINES`) which defaults to true and make `extract_plot_coords` oversample points which are distant from each other in order to make lines look straighter in `scattergeo`.

As part of this, all polyareas in the table of countries are fixed to ensure that the sign of the longitude at the lon=180 singularity is consistent with the neighboring points in each ring