### PR TITLE
refactor plot settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Changed the way plot settings are handled, and stop having `PLOT_STRAIGHT_LINES` being true by default.
+  - The user-customizable settings should now be set using the `with_settings` function (not exported)
+
+### Removed
+- Removed the method for `scattergeo` acting on vector of LatLon points as it was type piracy.
+
 ## [0.4.8] - 2025-03-21
 
 ### Added

--- a/ext/PlotlyBaseExt.jl
+++ b/ext/PlotlyBaseExt.jl
@@ -3,14 +3,8 @@ using PlotlyBase
 using CountriesBorders: Multi, Domain, PolyArea, extract_plot_coords, LatLon, 🌐, Point, RegionBorders
 
 function PlotlyBase.scattergeo(p::RegionBorders; kwargs...)
-	(;lon, lat) = extract_plot_coords(p)
+    (;lon, lat) = extract_plot_coords(p)
 	scattergeo(; lat, lon, mode="lines", kwargs...)
-end
-
-# This is type piracy so it should be removed probably
-function PlotlyBase.scattergeo(ps::Vector{<:Union{LatLon, Point{🌐, <:LatLon}}}; kwargs...)
-	(;lon, lat) = extract_plot_coords(ps)
-	scattergeo(; lat, lon, kwargs...)
 end
 
 end

--- a/src/plot_coordinates.jl
+++ b/src/plot_coordinates.jl
@@ -1,23 +1,74 @@
-"""
-    INSERT_NAN
-
-ScopedValue use to control whether to insert NaN before each ring within `extract_plot_coords!` unless we are in the first ring being inserted.
-
-Defaults to `true`
-"""
+# These are internal ScopedValues used to control the behavior of `extract_plot_coords!`. They are mirrored by keys of the same name in the `PLOT_SETTINGS` Dict which is also a ScopedValue and should be from users to control the behavior of `extract_plot_coords!`.
+# Specify whether to insert NaN before each vector of points within the lat/lon vectors
 const INSERT_NAN = Base.ScopedValues.ScopedValue{Bool}(true)
+#= 
+Specify whether `extract_plot_coords!` should potentially add artificial points between each pair of input points in order to have lines appear straight on scattergeo plots. This can have a symbol and three valid values (In reality, every symbol that is not the first two will be treated as `:NONE`)
+- `:NORMAL` will add artificial points only when necessary (when distance between points is too large) and will create lines that never cross the antimeridian. This is useful for example to plot Box geometries with large areas and have them still look like boxes.
+- `:SHORT` will add artificial points like per `:NORMAL` but will also make sure the line drawn between the points is the shortest one (potentially crossing the antimeridian at 180° longitude).
+- `:NONE` will not add artificial points
+=#
+const PLOT_STRAIGHT_LINES = Base.ScopedValues.ScopedValue{Symbol}(:NO)
+#= 
+Specify whether to close the vector of points by repeating the first point at the end of the vector.
+=#
+const CLOSE_VECTORS = Base.ScopedValues.ScopedValue{Bool}(false)
 
 """
-    PLOT_STRAIGHT_LINES
+    PLOT_SETTINGS
 
-ScopedValue use to control whether to plot straight lines between points within `extract_plot_coords!`.
-It does so by inserting artifical points if two points in a vector are too far in longitude (and would result in a curved line on the `scattergeo` plot).
+ScopedValue that contains the settings for `extract_plot_coords!`. It is a Dict with keys as symbol which can be used to customize the behavior of `extract_plot_coords!`.
 
-Defaults to `true`
+Check the docstring of [`with_settings`](@ref) for the possible keys accepted for this Dict.
 """
-const PLOT_STRAIGHT_LINES = Base.ScopedValues.ScopedValue{Bool}(true)
+const PLOT_SETTINGS = Base.ScopedValues.ScopedValue{Dict{Symbol, Any}}(Dict{Symbol, Any}())
 
-# This function will take two points in lat/lon and return a generator which produces more points to simulate straight lines on scattergeo plots. It has denser points closer to the poles as the distortion from scattergeo are more pronounced there
+"""
+    with_settings(f, settings::Pair{Symbol, <:Any}...)
+
+Convenience function to set the `PLOT_SETTINGS` ScopedValue to a Dict created from the key-value pairs in `settings` and call `f` with that `PLOT_SETTINGS` set.
+
+The possible keys that can be provided as settings are:
+- `:INSERT_NAN => Bool`: Specify whether to insert NaN before each vector of points within the lat/lon vectors.
+- `:PLOT_STRAIGHT_LINES => Symbol`: Specify whether `extract_plot_coords!` should potentially add artificial points between each pair of input points in order to have lines appear straight on scattergeo plots. This can have a symbol and three valid values (In reality, every symbol that is not the first two will be treated as `:NONE`)
+  - `:NORMAL` will add artificial points only when necessary (when distance between points is too large) and will create lines that never cross the antimeridian. This is useful for example to plot Box geometries with large areas and have them still look like boxes.
+  - `:SHORT` will add artificial points like per `:NORMAL` but will also make sure the line drawn between the points is the shortest one (potentially crossing the antimeridian at 180° longitude).
+  - `:NONE` will not add artificial points
+- `:CLOSE_VECTORS => Bool`: Specify whether to close the vector of points by repeating the first point at the end of the vector.
+
+This is essentially a convenience wrapper for:
+```julia
+Base.ScopedValues.with(CountriesBorders.PLOT_SETTINGS => Dict(settings...)) do
+    f()
+end
+```
+"""
+with_settings(f, settings::AbstractVector) = with_settings(f, settings...)
+function with_settings(f, settings::Pair{Symbol, <:Any}...)
+    Base.ScopedValues.with(PLOT_SETTINGS => Dict(settings...)) do
+        f()
+    end
+end
+
+should_insert_nan() = get(PLOT_SETTINGS[], :INSERT_NAN, INSERT_NAN[])
+should_shorten_straight_lines() = get(PLOT_SETTINGS[], :PLOT_STRAIGHT_LINES, PLOT_STRAIGHT_LINES[]) === :SHORT
+should_oversample_points() = get(PLOT_SETTINGS[], :PLOT_STRAIGHT_LINES, PLOT_STRAIGHT_LINES[]) ∈ (:SHORT, :NORMAL)
+should_close_vectors() = get(PLOT_SETTINGS[], :CLOSE_VECTORS, CLOSE_VECTORS[])
+
+function crossing_latitude_flat((lon1, lat1), (lon2, lat2))
+    Δlat = lat2 - lat1
+    coeff = 180 - lon1
+    den = lon2 + 360 - lon1
+    if lon1 <= 0
+        coeff = 180 + lon1
+        den = lon1 + 360 - lon2
+    end
+    return lat1 + coeff * Δlat / den
+end
+
+#= 
+This function will take two points in lat/lon and return a generator which produces more points to simulate straight lines on scattergeo plots. It has denser points closer to the poles as the distortion from scattergeo are more pronounced there.
+This function is also extremely heuristic, and can probably be improved significantly in terms of the algorithm
+=#
 function line_plot_coords(start, stop)
     lon1, lat1 = to_raw_coords(start)
     lon2, lat2 = to_raw_coords(stop)
@@ -26,13 +77,21 @@ function line_plot_coords(start, stop)
     if Δlon ≈ 0
         return (start,)
     end
+    if abs(Δlon) > 180 && should_shorten_straight_lines()
+        # We have to shorten and split at antimeridian
+        mid_lat = crossing_latitude_flat((lon1, lat1), (lon2, lat2))
+        return Iterators.flatten((
+            line_plot_coords(LatLon(lat1, lon1), LatLon(mid_lat, copysign(180, lon1))),
+            line_plot_coords(LatLon(mid_lat, copysign(180, lon2)), LatLon(lat2, lon2))
+        ))
+    end
     nrm = hypot(Δlat, Δlon)
     should_split = nrm > 10
     min_length = if should_split 
         10 
     else 
         maxlat = max(abs(lat1), abs(lat2))
-        val = (100 / min(maxlat, 10)) 
+        val = (100 / max(maxlat, 10)) 
         if maxlat > 65
             val /= 2
         end
@@ -70,11 +129,11 @@ function extract_plot_coords!(lat::Vector{T}, lon::Vector{T}, c::CART) where T<:
 end
 extract_plot_coords!(lat, lon, p::VALID_POINT) = extract_plot_coords!(lat, lon, coords(p))
 
-function extract_plot_coords!(lat, lon, els::AbstractVector{<:VALID_PLOT_COORD}; copy_first_point = false)
-    if INSERT_NAN[] && !isempty(lat) && !isempty(lon)
+function extract_plot_coords!(lat, lon, els::AbstractVector{<:VALID_PLOT_COORD})
+    if should_insert_nan() && !isempty(lat) && !isempty(lon)
         extract_plot_coords!(lat, lon, LatLon(NaN, NaN))
     end
-    if PLOT_STRAIGHT_LINES[]
+    if should_oversample_points()
         for i in eachindex(els)[1:end-1]
             start = els[i]
             stop = els[i+1]
@@ -89,21 +148,23 @@ function extract_plot_coords!(lat, lon, els::AbstractVector{<:VALID_PLOT_COORD};
             extract_plot_coords!(lat, lon, el)
         end
     end
-    if copy_first_point
+    if should_close_vectors()
         extract_plot_coords!(lat, lon, first(els))
     end
     return nothing
 end
-function extract_plot_coords!(lat, lon, els::AbstractVector; kwargs...)
+function extract_plot_coords!(lat, lon, els::AbstractVector)
     for el in els
-        extract_plot_coords!(lat, lon, el; kwargs...)
+        extract_plot_coords!(lat, lon, el)
     end
     return nothing
 end
 
 function extract_plot_coords!(lat, lon, ring::VALID_RING)
     # We plot the points in the ring
-    extract_plot_coords!(lat, lon, vertices(ring); copy_first_point = true)
+    Base.ScopedValues.with(CLOSE_VECTORS => true) do
+        extract_plot_coords!(lat, lon, vertices(ring))
+    end
     return nothing
 end
 
@@ -121,11 +182,11 @@ and `lon` contain the concateneated lat/lon values of each ring separated by
 `NaN32` values. This is done to allow plotting multiple separated borders in a
 single trace.
 """
-function extract_plot_coords!(lat, lon, inp; kwargs...)
+function extract_plot_coords!(lat, lon, inp)
     applicable(geom_iterable, inp) || throw(ArgumentError("last input of `extract_plot_coords!` must implement the `geom_iterable` function to use the generic fallback. Alternatively, a specific method for `extract_plot_coords!(lat, lon, inp)` must be implemented for type $(typeof(inp))."))
     iterable = geom_iterable(inp)
     for geom ∈ iterable
-        extract_plot_coords!(lat, lon, geom; kwargs...)
+        extract_plot_coords!(lat, lon, geom)
     end
     return nothing
 end
@@ -137,10 +198,10 @@ Returns a NamedTuple with two vectors `lat` and `lon` containing the correspondi
 
 This is mostly intended to simplify creation of the `lat` and `lon` keyword arguments to provide to the `scattergeo` function from `PlotlyBase`. By default points are converted to Float32 and NaN values are inserted between each `Ring` to allow plotting multiple polyareas within a single trace.
 """
-function extract_plot_coords(T::Type{<:AbstractFloat}, item; kwargs...)
+function extract_plot_coords(T::Type{<:AbstractFloat}, item)
     lat = T[]
     lon = T[]
-    extract_plot_coords!(lat, lon, item; kwargs...)
+    extract_plot_coords!(lat, lon, item)
     return (; lat, lon)
 end
-extract_plot_coords(item; kwargs...) = extract_plot_coords(Float32, item; kwargs...)
+extract_plot_coords(item) = extract_plot_coords(Float32, item)

--- a/test/extensions.jl
+++ b/test/extensions.jl
@@ -29,20 +29,3 @@ end
     @test count(isnan, sg_italy.lat) == 2
     @test count(isnan, sg_italy_nosicily.lat) == 1
 end
-
-@testitem "Points" setup = [setup_extensions] begin
-    using CountriesBorders: PLOT_STRAIGHT_LINES
-    cities = [
-        SimpleLatLon(41.9, 12.49) # Rome
-        SimpleLatLon(39.217, 9.113) # Cagliari
-        SimpleLatLon(48.864, 2.349) # Paris
-        SimpleLatLon(59.913, 10.738) # Oslo
-    ]
-
-    sg = Base.ScopedValues.with(PLOT_STRAIGHT_LINES => false) do
-        cities |> scattergeo
-    end
-
-    @test sg.lat == map(x -> x.lat |> ustrip |> Float32, cities)
-    @test sg.lon == map(x -> x.lon |> ustrip |> Float32, cities)
-end


### PR DESCRIPTION
This PR fixes some hidden breaking in downstream packages using CountriesBorders that was introduced in #51 
It also changes the way to customize behavior of `extract_plot_coords` which should now be done using the `non-exported` `with_settings` function