### PR TITLE
implement FastInRegion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.4.13] - 2025-06-29
+
+### Added 
+- Added a new abstract type `FastInRegion` which represents all types for which our custom point inclusion algorithm (based on `in_exit_early`) should work
+  - This is mostly added to simplify defining custom regions in downstream packages without requiring to define a custom `Base.in` method for every new type.
+
+## [0.4.12] - 2025-04-02
+
+### Fixed
+- Fix missing import which caused erroring in 0.4.11
+
 ## [0.4.11] - 2025-04-02
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CountriesBorders"
 uuid = "ee40d4b5-31c3-4fe2-b6cc-5ac7adf7f414"
 authors = ["Alberto Mengali <disberd@gmail.com>"]
-version = "0.4.12"
+version = "0.4.13"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/CountriesBorders.jl
+++ b/src/CountriesBorders.jl
@@ -19,7 +19,7 @@ using ScopedValues: ScopedValues, ScopedValue, with
 export LatLon, Point
 
 include("types.jl")
-export CountryBorder, SimpleLatLon, SkipFromAdmin
+export CountryBorder, SimpleLatLon, SkipFromAdmin, FastInRegion
 
 # These two constants are used to customize the default resolution of the geotable with borders and coastlines
 const DEFAULT_RESOLUTION = Ref{Int}(110)

--- a/src/meshes_interface.jl
+++ b/src/meshes_interface.jl
@@ -7,7 +7,18 @@ borders(x) = borders(LatLon, x)
 resolution(cb::CountryBorder) = cb.resolution
 resolution(d::DOMAIN) = resolution(element(d, 1))
 
-# This should return a vector of POLY_CART elements, mostly to be used with in_exit_early
+"""
+    polyareas(region)
+
+Returns an iterable of the cartesian polygons (`<:POLY_CART`) associated to the provided `region`.
+
+This function is mainly used in the implementation of the custom fast point inclusion algorithm in [`CountriesBorders.in_exit_early`](@ref).
+
+!!! note
+    This function is not part of the package's public API and might be subject to change in future versions. When made public, this will most likely follow the signature of `borders` with 2 arguments where the first can be either `LatLon` or `Cartesian`.
+
+See also [`CountriesBorders.in_exit_early`](@ref), [`CountriesBorders.bboxes`](@ref).
+"""
 polyareas(x) = polyareas(borders(Cartesian, x))
 polyareas(v::Vector{<:POLY_CART}) = v
 polyareas(x::MULTI_CART) = parent(x)
@@ -27,7 +38,18 @@ function polyareas(b::BOX_CART)
 end
 polyareas(dmn::DOMAIN) = Iterators.flatten(polyareas(el) for el in dmn)
 
-# This should return the cartesian bounding boxes for the polyareas of x, mostly to be used with in_exit_early
+"""
+    bboxes(region)
+
+Returns an iterable of the cartesian bounding boxes (`<:BBOX_CART`) associated to the provided `region`.
+
+This function is mainly used in the implementation of the custom fast point inclusion algorithm in [`CountriesBorders.in_exit_early`](@ref).
+
+!!! note
+    This function is not part of the package's public API and might be subject to change in future versions. When made public, this will most likely follow the signature of `borders` with 2 arguments where the first can be either `LatLon` or `Cartesian`.
+
+See also [`CountriesBorders.in_exit_early`](@ref), [`CountriesBorders.polyareas`](@ref).
+"""
 bboxes(x) = map(boundingbox, polyareas(x))
 bboxes(b::BOX_CART) = (b,)
 bboxes(cb::CountryBorder) = cb.bboxes
@@ -93,7 +115,7 @@ Base.parent(crs::VALID_CRS, cb::CountryBorder) = parent(borders(crs, cb))
     in_exit_early(p, polys, bboxes)
 Function that checks if a point is contained one of the polyareas in vector `polys` which are associated to the bounding boxes in vector `bboxes`.
 
-Both `polys` and `bboxes` must be vectors of the same size, with element type `POLY_CART` and `BBOX_CART` respectively.
+Both `polys` and `bboxes` must be iterables of the same size, with element type `POLY_CART` and `BBOX_CART` respectively.
 
 This function is basically pre-filtering points by checking inclusion in the bounding box which is significantly faster than checking for the polyarea itself.
 """

--- a/src/types.jl
+++ b/src/types.jl
@@ -19,6 +19,20 @@ const BOX_LATLON{T} = Box{🌐, LATLON{T}}
 const BOX_CART{T} = Box{𝔼{2}, CART{T}}
 
 """
+    FastInRegion{T} <: Geometry{🌐,LATLON{T}}
+
+Abstract type identifying regions where a fast custom algorithm for checking point inclusion in region is available. 
+
+Subtypes of `FastInRegion` are expected to support support the `CountriesBorders.in_exit_early` function.
+For most types, the default implementation is sufficient and translates into having a working method for the following two functions defined in CountriesBorders.jl:
+- `polyareas`
+- `bboxes`
+
+See also [`CountriesBorders.in_exit_early`](@ref), [`CountriesBorders.polyareas`](@ref), [`CountriesBorders.bboxes`](@ref).
+"""
+abstract type FastInRegion{T} <: Geometry{🌐,LATLON{T}} end
+
+"""
     CountryBorder{T} <: Geometry{🌐,LATLON{T}}
 
 Structure representings the coordinates of the borders of a country (based on the NaturalEarth database). 
@@ -35,7 +49,7 @@ This structure holds the borders in both LatLon and Cartesian2D, to allow faster
 - `latlon::MULTI_LATLON{T}`: The borders in LatLon CRS.
 - `cart::MULTI_LATLON{T}`: The borders in Cartesian2D CRS.
 """
-struct CountryBorder{T} <: Geometry{🌐,LATLON{T}}
+struct CountryBorder{T} <: FastInRegion{T}
     "Name of the Country, i.e. the ADMIN entry in the GeoTable"
     admin::String
     "The index of the country in the original GeoTable"
@@ -57,7 +71,7 @@ const SUBDOMAIN{T} = SubDomain{🌐, LATLON{T}, <:GSET{T}}
 const DOMAIN{T} = Union{GSET{T}, SUBDOMAIN{T}}
 
 const SimpleLatLon = LatLon # To Remove in next breaking
-const RegionBorders{T} = Union{CountryBorder{T}, DOMAIN{T}}
+const RegionBorders{T} = Union{FastInRegion{T}, DOMAIN{T}}
 
 """
     SkipFromAdmin(admin::AbstractString, idxs::AbstractVector{<:Integer})


### PR DESCRIPTION
- Added a new abstract type `FastInRegion` which represents all types for which our custom point inclusion algorithm (based on `in_exit_early`) should work
  - This is mostly added to simplify defining custom regions in downstream packages without requiring to define a custom `Base.in` method for every new type.