### PR TITLE
define valuetype methods in `BasicTypes` to avoid piracy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ PlotlyBaseExt = "PlotlyBase"
 
 [compat]
 Artifacts = "1"
-BasicTypes = "1.12.0"
+BasicTypes = "1.13.0"
 CircularArrays = "1.4.0"
 CoordRefSystems = "0.16 - 0.18"
 GeoInterface = "1"

--- a/src/meshes_interface.jl
+++ b/src/meshes_interface.jl
@@ -131,8 +131,7 @@ end
 # This is a catchall method for extension for other types
 in_exit_early(p, x) = in_exit_early(p, polyareas(x), bboxes(x))
 
-Base.in(p::VALID_POINT, cb::CountryBorder) = in_exit_early(p, cb)
-Base.in(p::LATLON, dmn::Union{DOMAIN, CountryBorder}) = in(Point(p), dmn)
+Base.in(p::Union{VALID_POINT, LATLON}, d::RegionBorders) = in_exit_early(p, d)
 
 # IO related
 function Meshes.prettyname(d::GSET) 

--- a/src/types.jl
+++ b/src/types.jl
@@ -67,7 +67,7 @@ struct CountryBorder{T} <: FastInRegion{T}
 end
 
 const GSET{T} = GeometrySet{🌐, LATLON{T}, CountryBorder{T}}
-const SUBDOMAIN{T} = SubDomain{🌐, LATLON{T}, <:GSET{T}}
+const SUBDOMAIN{T} = SubDomain{🌐, LATLON{T}, GSET{T}}
 const DOMAIN{T} = Union{GSET{T}, SUBDOMAIN{T}}
 
 const SimpleLatLon = LatLon # To Remove in next breaking


### PR DESCRIPTION
This PR removes some methods added for `BasicTypes.valuetype` as they are now available in `BasicTypes` as extension