### PR TITLE
actually remove valuetype methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.4.13] - 2025-06-29
+## [0.4.13] - 2025-06-31
 
 ### Added 
 - Added a new abstract type `FastInRegion` which represents all types for which our custom point inclusion algorithm (based on `in_exit_early`) should work
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The internal function (`floattype`) to extract floating point type for types defined by CountriesBorders has been replaced by `BasicTypes.valuetype`
 - Make the default method for internal `to_cart_point` and `to_latlon_point` rely on `GeoPlottingHelpers.to_raw_lonlat` for simpler extension in downstream packages
 - Make internal functions relying on JuliaEarth ecosystem more consistent with the public API (we still rely on some internals)
+
+### Fixed
+- The accepted `valuetype` as input to `latlon_geometry`, `cartesian_geometry` and `change_geometry` is `<:AbstractFloat` rather than `<:Real` to be consistent with the Meshes API
 
 ## [0.4.12] - 2025-04-02
 

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -1,10 +1,3 @@
-BasicTypes.valuetype(::Type{<:CountryBorder{T}}) where {T} = return T
-BasicTypes.valuetype(::Type{<:DOMAIN{T}}) where {T} = return T
-BasicTypes.valuetype(::Type{<:Geometry{🌐,LATLON{T}}}) where T = return T
-BasicTypes.valuetype(::Type{<:Geometry{𝔼{2},CART{T}}}) where T = return T
-BasicTypes.valuetype(::Type{<:Union{LATLON{T}, CART{T}}}) where T = return T
-BasicTypes.valuetype(::Type{<:VALID_POINT{T}}) where T = return T
-
 function to_raw_coords(x)
     @warn "to_raw_coords is deprecated, use GeoPlottingHelpers.to_raw_lonlat instead (which is already a dependency of CountriesBorders)"
     to_raw_lonlat(x)
@@ -28,81 +21,80 @@ end
 
 
 """
-    cartesian_geometry([T::Type{<:Real}, ] geom)
-    cartesian_geometry(T::Type{<:Real})
+    cartesian_geometry([T::Type{<:AbstractFloat}, ] geom)
+    cartesian_geometry(T::Type{<:AbstractFloat})
 
 Convert geometries from LatLon to Cartesian coordinate systems, optionally changing the underlying machine type of the points to `T`
 
 The second method simply returns a function that applies the conversion with the provided machine type to any geometry.
 
 ## Arguments
-- `T::Type{<:Real}`: The desired machine type of the points in the output geometry. If not provided, it will default to the machine type of the input geometry.
+- `T::Type{<:AbstractFloat}`: The desired machine type of the points in the output geometry. If not provided, it will default to the machine type of the input geometry.
 - `geom`: The geometry to convert, which can be an arbitrary Geometry either in LatLon{WGS84Latest} or Cartesian2D{WGS84Latest} coordinates.
 
 ## Returns
 - The converted geometry, with points of type `POINT_CART{T}`.
 """
-function cartesian_geometry(T::Type{<:Real}, b::Union{BOX_LATLON, BOX_CART})
+function cartesian_geometry(T::Type{<:AbstractFloat}, b::Union{BOX_LATLON, BOX_CART})
     b isa BOX_CART{T} && return b
     f = to_cart_point(T)
     return BOX_CART{T}(f(b.min), f(b.max))
 end
-function cartesian_geometry(T::Type{<:Real}, ring::Union{RING_CART, RING_LATLON})
+function cartesian_geometry(T::Type{<:AbstractFloat}, ring::Union{RING_CART, RING_LATLON})
     ring isa RING_CART{T} && return ring
     map(to_cart_point(T), vertices(ring)) |> Ring
 end
-function cartesian_geometry(T::Type{<:Real}, poly::Union{POLY_LATLON, POLY_CART})
+function cartesian_geometry(T::Type{<:AbstractFloat}, poly::Union{POLY_LATLON, POLY_CART})
     poly isa POLY_CART{T} && return poly
     map(cartesian_geometry(T), rings(poly)) |> splat(PolyArea)
 end
-function cartesian_geometry(T::Type{<:Real}, multi::Union{MULTI_LATLON, MULTI_CART})
+function cartesian_geometry(T::Type{<:AbstractFloat}, multi::Union{MULTI_LATLON, MULTI_CART})
     multi isa MULTI_CART{T} && return multi
     map(cartesian_geometry(T), parent(multi)) |> Multi
 end
-cartesian_geometry(T::Type{<:Real}) = Base.Fix1(cartesian_geometry, T)
+cartesian_geometry(T::Type{<:AbstractFloat}) = Base.Fix1(cartesian_geometry, T)
 cartesian_geometry(x) = cartesian_geometry(valuetype(x), x)
 
 """
-    latlon_geometry([T::Type{<:Real}, ] geom)
-    latlon_geometry(T::Type{<:Real})
+    latlon_geometry([T::Type{<:AbstractFloat}, ] geom)
+    latlon_geometry(T::Type{<:AbstractFloat})
 
 Convert geometries from Cartesian to LatLon coordinate systems, optionally changing the underlying machine type of the points to `T`
 
 The second method simply returns a function that applies the conversion with the provided machine type to any geometry. 
 
 ## Arguments
-- `T::Type{<:Real}`: The desired machine type of the points in the output geometry. If not provided, it will default to the machine type of the input geometry.
+- `T::Type{<:AbstractFloat}`: The desired machine type of the points in the output geometry. If not provided, it will default to the machine type of the input geometry.
 - `geom`: The geometry to convert, which can be an arbitrary Geometry either in LatLon{WGS84Latest} or Cartesian2D{WGS84Latest} coordinates.
 
 ## Returns
 - The converted geometry, with points of type `POINT_LATLON{T}`.
 
 """
-function latlon_geometry(T::Type{<:Real}, b::Union{BOX_LATLON, BOX_CART})
+function latlon_geometry(T::Type{<:AbstractFloat}, b::Union{BOX_LATLON, BOX_CART})
     b isa BOX_LATLON{T} && return b
     f = to_latlon_point(T)
     return BOX_LATLON{T}(f(b.min), f(b.max))
 end
-function latlon_geometry(T::Type{<:Real}, ring::Union{RING_CART, RING_LATLON})
+function latlon_geometry(T::Type{<:AbstractFloat}, ring::Union{RING_CART, RING_LATLON})
     ring isa RING_LATLON{T} && return ring
     map(to_latlon_point(T), vertices(ring)) |> Ring
 end
-function latlon_geometry(T::Type{<:Real}, poly::Union{POLY_LATLON, POLY_CART})
+function latlon_geometry(T::Type{<:AbstractFloat}, poly::Union{POLY_LATLON, POLY_CART})
     poly isa POLY_LATLON{T} && return poly
     map(latlon_geometry(T), rings(poly)) |> splat(PolyArea)
 end
-function latlon_geometry(T::Type{<:Real}, multi::Union{MULTI_LATLON, MULTI_CART})
+function latlon_geometry(T::Type{<:AbstractFloat}, multi::Union{MULTI_LATLON, MULTI_CART})
     multi isa MULTI_LATLON{T} && return multi
     map(latlon_geometry(T), parent(multi)) |> Multi
 end
-latlon_geometry(T::Type{<:Real}) = Base.Fix1(latlon_geometry, T)
+latlon_geometry(T::Type{<:AbstractFloat}) = Base.Fix1(latlon_geometry, T)
 latlon_geometry(x) = latlon_geometry(valuetype(x), x)
 
 
 """
-    change_geometry(crs::Type{Cartesian}[, T::Type{<:Real}], x)
-    change_geometry(crs::Type{LatLon}[, T::Type{<:Real}], x)
-    change_geometry(crs[, T::Type{<:Real}])
+    change_geometry(crs::Type{Cartesian}[, T::Type{<:AbstractFloat}], x)
+    change_geometry(crs::Type{LatLon}[, T::Type{<:AbstractFloat}], x)
 
 Change the underlying CRS of a geometry from Cartesian to LatLon (or vice versa) and optionally change the underlying machine type of the points to `T`.
 
@@ -111,12 +103,12 @@ The last method only taking `Cartesian` or `LatLon` as input (and optionally the
 !!! note
     This method simply forwards the input to either the `cartesian_geometry` or `latlon_geometry` function based on the value of `crs`.
 """
-change_geometry(::Type{Cartesian}, T::Type{<:Real}, x) = cartesian_geometry(T, x)
-change_geometry(::Type{LatLon}, T::Type{<:Real}, x) = latlon_geometry(T, x)
+change_geometry(::Type{Cartesian}, T::Type{<:AbstractFloat}, x) = cartesian_geometry(T, x)
+change_geometry(::Type{LatLon}, T::Type{<:AbstractFloat}, x) = latlon_geometry(T, x)
 change_geometry(crs::Union{Type{Cartesian}, Type{LatLon}}, x) = change_geometry(crs, valuetype(x), x)
 change_geometry(crs::Union{Type{Cartesian}, Type{LatLon}}) = Base.Fix1(change_geometry, crs)
-change_geometry(::Type{Cartesian}, ::Type{T}) where {T <: Real} = x -> change_geometry(Cartesian, T, x)
-change_geometry(::Type{LatLon}, ::Type{T}) where {T <: Real} = x -> change_geometry(LatLon, T, x)
+change_geometry(::Type{Cartesian}, ::Type{T}) where {T <: AbstractFloat} = x -> change_geometry(Cartesian, T, x)
+change_geometry(::Type{LatLon}, ::Type{T}) where {T <: AbstractFloat} = x -> change_geometry(LatLon, T, x)
 
 function check_resolution(resolution::Union{Nothing, Real}; force::Bool = false)
     force && isnothing(resolution) && throw(ArgumentError("You can't force a computation without specifying the resolution"))


### PR DESCRIPTION
This PR actually remove the `valuetype` methods from this package that were supposed to be removed in #57.

It also restricts supported type to `latlon_geometry`, `cartesian_geometry` and `change_geometry` to be a subtype of `AbstractFloat` (instead of `Real`) to be aligned with the Meshes Public API which expects precision of its fields to be a floating point number