### PR TITLE
Fix error introduced by Meshes v0.55.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.5.3] - 2025-11-08
+
+### Fixed
+- Fixed a supertype not correctly working due to changes in Meshes.jl v0.55.2, leading to errors in tests and in the `resolution` method.
+
 ## [0.5.2] - 2025-10-06
 ### Changed
 - Bumped the compat of CoordRefSystems.jl to support v0.19

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CountriesBorders"
 uuid = "ee40d4b5-31c3-4fe2-b6cc-5ac7adf7f414"
 authors = ["Alberto Mengali <disberd@gmail.com>"]
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/types.jl
+++ b/src/types.jl
@@ -27,7 +27,11 @@ struct CountryBorder{T} <: FastInGeometry{T}
     borders::GeoBorders{T}
 end
 
-const GSET{T} = GeoBasics.FastInGeometrySet{T, CountryBorder{T}}
+const GSET{T} = @static if pkgversion(Meshes) < v"0.55.2" 
+    GeoBasics.FastInGeometrySet{T, CountryBorder{T}} 
+else 
+    GeoBasics.FastInGeometrySet{T, CountryBorder{T}}{Vector{CountryBorder{T}}} 
+end
 const SUBDOMAIN{T} = GeoBasics.FastInSubDomain{T, GSET{T}}
 const DOMAIN{T} = Union{GSET{T}, SUBDOMAIN{T}}
 


### PR DESCRIPTION
The error here was caused by `FastInSubDomain` mapping the exact provided `GSET{T}` type to a `Meshes.SubDomain`, and the fact that for an arbitrary parametry type, `MyType{T} <: MyType{G}` is not true even if `T <: G`.

The fix could als have been to update the definition `const SUBDOMAIN{T} = GeoBasics.FastInSubDomain{T, <:GSET{T}}`, but for the moment this also makes `GSET{T}` fully concrete